### PR TITLE
adding the normalizeUsing option that was missing in the modules.config deeptools/bamCoverage

### DIFF
--- a/conf/modules.config
+++ b/conf/modules.config
@@ -138,10 +138,12 @@ process {
         ext.args = [
             params.extendReads ? "--extendReads ${params.extendReads}" : '',
             "--binSize ${params.binSize}",
+            "--normalizeUsing ${params.normalizeUsing}",
             params.effectiveGenomeSize ? "--effectiveGenomeSize ${params.effectiveGenomeSize}" : '',
             params.ignoreForNormalization ? "--ignoreForNormalization  ${params.ignoreForNormalization}" : '',
             "--ignoreDuplicates"
         ].join(' ').trim()
+        ext.prefix = { "${meta.id}.q${params.q_score}.${params.normalizeUsing}" }
         publishDir = [
             path: { "${params.outdir}/single_tracks/deeptools" },
             mode: params.publish_dir_mode,

--- a/docs/output.md
+++ b/docs/output.md
@@ -14,6 +14,7 @@ The pipeline is built using [Nextflow](https://www.nextflow.io/) and processes d
 - [Trim reads](#trim-reads)
 - [Alignment on Reference](#alignment-on-reference)
 - [Mark Duplicate reads](#mark-duplicate-reads)
+- [Reads filtering](#read-filtering)
 - [Signal track generation](#signal-track-generation)
 - [Comparisons](#comparisons)
 - [MultiQC](#multiqc)
@@ -49,10 +50,6 @@ The FastQC plots displayed in the MultiQC report shows both _untrimmed_ and _tri
 The alignment is performed using [BWA](https://github.com/lh3/bwa) and the aligned reads are then sorted by chromosome coordinates with [samtools](https://www.htslib.org/doc/samtools.html).
 
 <details markdown="1">
-<summary>Output files</summary>
-
-- `alignment/bwa/`
-  - `<sample>.bam` and `<sample>.bam.bai`
 
 </details>
 
@@ -70,15 +67,30 @@ Read pairs that are likely to have originated from duplicates of the same origin
 
 </details>
 
+### Mark Duplicate reads
+
+The BAM files generated are further processed with SAMtools for filtering (based on samtools flags and quality score) and indexing, as well as to generate read mapping statistics.
+<details markdown="1">
+<summary>Output files</summary>
+
+- `alignment/filtered/`
+  - `<sample>.<q_score>.bam` and `<sample>.<q_score>.bam.bai`
+- `/reports/samtools_stats/<sample>/filtered/`
+  - `<sample>/filtered.idxstats`
+  - `<sample>/filtered.flagstat`
+  - `<sample>/filtered.stats`
+</details>
+
 ### Signal track generation
 
 [deepTools](https://deeptools.readthedocs.io/en/develop/content/list_of_tools.html) is used to generate single fraction signals in [bigWig](https://genome.ucsc.edu/goldenpath/help/bigWig.html) format, an indexed binary format useful for displaying dense, continuous data in Genome Browsers such as the [UCSC](https://genome.ucsc.edu/cgi-bin/hgTracks) and [IGV](http://software.broadinstitute.org/software/igv/). The bigWig format is also supported by various bioinformatics software for downstream processing such as meta-profile plotting.
+The generated signal tracks represent read coverage and can be normalized using different methods: RPKM (default option),CPM, BPM and RPGC.
 
 <details markdown="1">
 <summary>Output files</summary>
 
 - `single_tracks/deeptools/`
-  - `<sample>.bigWig`
+  - `<sample>.<q_score>.<normalizeUsing>.bw`
 
 </details>
 

--- a/docs/output.md
+++ b/docs/output.md
@@ -70,6 +70,7 @@ Read pairs that are likely to have originated from duplicates of the same origin
 ### Mark Duplicate reads
 
 The BAM files generated are further processed with SAMtools for filtering (based on samtools flags and quality score) and indexing, as well as to generate read mapping statistics.
+
 <details markdown="1">
 <summary>Output files</summary>
 
@@ -79,7 +80,7 @@ The BAM files generated are further processed with SAMtools for filtering (based
   - `<sample>/filtered.idxstats`
   - `<sample>/filtered.flagstat`
   - `<sample>/filtered.stats`
-</details>
+  </details>
 
 ### Signal track generation
 


### PR DESCRIPTION
In the last pull request the NormalizingUsing parameter of deeptools/bamCoverage was missing in the modules.config .
So I fixed it by editing the modules.config file:
1) Adding `"--normalizeUsing ${params.normalizeUsing}",`
2) Updating  `ext.prefix = { "${meta.id}.q${params.q_score}.${params.normalizeUsing}" }`

<!--
# nf-core/sammyseq pull request

Many thanks for contributing to nf-core/sammyseq!

Please fill in the appropriate checklist below (delete whatever is not relevant).
These are the most common things requested on pull requests (PRs).

Remember that PRs should be made against the dev branch, unless you're preparing a pipeline release.

Learn more about contributing: [CONTRIBUTING.md](https://github.com/nf-core/sammyseq/tree/master/.github/CONTRIBUTING.md)
-->

## PR checklist

- [x] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/nf-core/sammyseq/tree/master/.github/CONTRIBUTING.md)
- [ ] If necessary, also make a PR on the nf-core/sammyseq _branch_ on the [nf-core/test-datasets](https://github.com/nf-core/test-datasets) repository.
- [x] Make sure your code lints (`nf-core pipelines lint`).
- [x] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [x] Check for unexpected warnings in debug mode (`nextflow run . -profile debug,test,docker --outdir <OUTDIR>`).
- [ ] Usage Documentation in `docs/usage.md` is updated.
- [x] Output Documentation in `docs/output.md` is updated.
- [ ] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).
