### PR TITLE
add bowtie2 params and fix no input blacklist

### DIFF
--- a/conf/modules.config
+++ b/conf/modules.config
@@ -64,12 +64,17 @@ process {
 
     if (params.aligner == 'bowtie2') {
     withName: '.*FASTQ_ALIGN_BOWTIE2:.*' {
+        ext.args   = '--end-to-end --non-deterministic --very-sensitive'
         publishDir = [
             enabled: false
             ]
         }
     withName: '.*FASTQ_ALIGN_BOWTIE2:.*:SAMTOOLS_SORT' {
         ext.prefix = { "${meta.id}.sorted" }
+        ext.args   = ''
+        }
+    withName: '.*FASTQ_ALIGN_BOWTIE2:.*:SAMTOOLS_INDEX' {
+        ext.args   = ''
         }
     }
 

--- a/workflows/sammyseq.nf
+++ b/workflows/sammyseq.nf
@@ -389,7 +389,7 @@ if (params.stopAt == 'ALIGNMENT') {
         ch_bam_bai_filtered,
         ch_fasta_path,
         ch_fai_path,
-        PREPARE_GENOME.out.blacklist
+        params.blacklist ? PREPARE_GENOME.out.blacklist : []
     )
 
     ch_versions = ch_versions.mix(DEEPTOOLS_BAMCOVERAGE.out.versions)
@@ -402,7 +402,7 @@ if (params.stopAt == 'ALIGNMENT') {
         FILTER_BAM_SAMTOOLS.out.bam,
         FILTER_BAM_SAMTOOLS.out.bai,
         params.corr_method,
-        PREPARE_GENOME.out.blacklist
+        params.blacklist ? PREPARE_GENOME.out.blacklist : []
     )
     ch_dt_corrmatrix     = DEEPTOOLS_QC.out.correlation_matrix
     ch_dt_pcadata        = DEEPTOOLS_QC.out.pca_data


### PR DESCRIPTION
improved (1) Bowtie2 alignment precision and (2) fixed deeptools bamcoverage execution

1. Added the following default parameters to the Bowtie2 alignment step:
   - '--end-to-end':
   - '--non-deterministic':
   - '--very-sensitive'

2. DeepTools bamCoverage Fix:
Fixes an issue where the deeptools bamcoverage module would not run when no blacklist was provided as input. The module now executes correctly regardless of blacklist presence.

## PR checklist

- [X] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/nf-core/sammyseq/tree/master/.github/CONTRIBUTING.md)
- [ ] If necessary, also make a PR on the nf-core/sammyseq _branch_ on the [nf-core/test-datasets](https://github.com/nf-core/test-datasets) repository.
- [X] Make sure your code lints (`nf-core pipelines lint`).
- [X] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [X] Check for unexpected warnings in debug mode (`nextflow run . -profile debug,test,docker --outdir <OUTDIR>`).
- [ ] Usage Documentation in `docs/usage.md` is updated.
- [ ] Output Documentation in `docs/output.md` is updated.
- [ ] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).
