### PR TITLE
Add makewindows and separate by chrs modules and change deeptools parameters name

### DIFF
--- a/assets/schema_input.json
+++ b/assets/schema_input.json
@@ -38,6 +38,12 @@
                 "pattern": "^\\S+$",
                 "errorMessage": "fraction must be provided and cannot contain spaces",
                 "meta": ["fraction"]
+            },
+            "sample_group": {
+                "type": "string",
+                "pattern": "^\\S+$",
+                "errorMessage": "sample_group must be provided and cannot contain spaces",
+                "meta": ["sample_group"]
             }
         },
         "required": ["sample", "fastq_1", "experimentalID", "fraction"]

--- a/conf/modules.config
+++ b/conf/modules.config
@@ -25,6 +25,23 @@ process {
         ]
     }
 
+    withName: ".*BEDTOOLS_MAKEWINDOWS.*" {
+        ext.args = { "-w ${params.binsize}" }
+        publishDir = [
+            enabled: false
+        ]
+    }
+
+    withName: ".*BIN_BY_CHROMOSOME.*" {
+        ext.prefix = { "${meta.id}.bin${params.binsize}"}
+        publishDir = [
+            path: { "${params.outdir}/genome/bin_by_chromosome" },
+            mode: params.publish_dir_mode,
+            saveAs: { filename -> filename.equals('versions.yml') ? null : filename },
+            enabled: true
+        ]
+    }
+
     withName: 'MULTIQC' {
         ext.args   = { params.multiqc_title ? "--title \"$params.multiqc_title\"" : '' }
         publishDir = [
@@ -163,7 +180,7 @@ process {
     withName: '.*DEEPTOOLS_BAMCOVERAGE.*' {
         ext.args = [
             params.extendReads ? "--extendReads ${params.extendReads}" : '',
-            "--binSize ${params.binSize}",
+            "--binSize ${params.bw_resolution}",
             "--normalizeUsing ${params.normalizeUsing}",
             params.effectiveGenomeSize ? "--effectiveGenomeSize ${params.effectiveGenomeSize}" : '',
             params.ignoreForNormalization ? "--ignoreForNormalization ${params.ignoreForNormalization}" : '',
@@ -181,7 +198,7 @@ process {
     withName: '.*DEEPTOOLS_QC:DEEPTOOLS_MULTIBAMSUMMARY.*' {
         ext.args = [
             "--smartLabels",
-            "--binSize ${params.bam_binsize}",
+            "--binSize ${params.binsize}",
             "--outRawCounts outRawCounts.txt",
             // params.blacklist ? "--blackListFileName ${params.blacklist}" : '',
             params.extendReads ? "--extendReads ${params.extendReads}" : '',

--- a/main.nf
+++ b/main.nf
@@ -36,6 +36,7 @@ params.bowtie2_index = getGenomeAttribute('bowtie2')
 //params.gff           = getGenomeAttribute('gff')
 //params.gene_bed      = getGenomeAttribute('gene_bed')
 params.blacklist     = getGenomeAttribute('blacklist')
+params.binsize   = getGenomeAttribute('binsize')
 
 /*
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/modules.json
+++ b/modules.json
@@ -5,6 +5,11 @@
         "https://github.com/nf-core/modules.git": {
             "modules": {
                 "nf-core": {
+                    "bedtools/makewindows": {
+                        "branch": "master",
+                        "git_sha": "81880787133db07d9b4c1febd152c090eb8325dc",
+                        "installed_by": ["modules"]
+                    },
                     "bowtie2/align": {
                         "branch": "master",
                         "git_sha": "81880787133db07d9b4c1febd152c090eb8325dc",

--- a/modules/local/bin_by_chromosome.nf
+++ b/modules/local/bin_by_chromosome.nf
@@ -1,0 +1,25 @@
+process BIN_BY_CHROMOSOME {
+    tag "$meta.id"
+
+    input:
+    tuple val(meta), path(bed)
+    path(chrom_sizes)
+
+    output:
+    tuple val(meta), path("*.bed"), emit: chrom_beds
+
+    script:
+    """
+    # Count the number of chromosomes in chrom_sizes
+    chrom_count=\$(wc -l < ${chrom_sizes})
+
+    if [ \$chrom_count -eq 1 ]; then
+        # If there's only one chromosome, create a new file with the chromosome name
+        chrom_name=\$(cut -f1 ${chrom_sizes})
+        cp ${bed} \${chrom_name}.binned.bed
+    else
+        # If there are multiple chromosomes, use the original awk command
+        awk 'NR==FNR{list[\$1]=1; next} \$1 in list{print > \$1".binned.bed"}' ${chrom_sizes} ${bed}
+    fi
+    """
+}

--- a/modules/nf-core/bedtools/makewindows/environment.yml
+++ b/modules/nf-core/bedtools/makewindows/environment.yml
@@ -1,0 +1,7 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/nf-core/modules/master/modules/environment-schema.json
+channels:
+  - conda-forge
+  - bioconda
+dependencies:
+  - bioconda::bedtools=2.31.1

--- a/modules/nf-core/bedtools/makewindows/main.nf
+++ b/modules/nf-core/bedtools/makewindows/main.nf
@@ -1,0 +1,49 @@
+process BEDTOOLS_MAKEWINDOWS {
+    tag "$meta.id"
+    label 'process_single'
+
+    conda "${moduleDir}/environment.yml"
+    container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
+        'https://depot.galaxyproject.org/singularity/bedtools:2.31.1--hf5e1c6e_0' :
+        'biocontainers/bedtools:2.31.1--hf5e1c6e_0' }"
+    
+    input:
+    tuple val(meta), path(regions)
+
+    output:
+    tuple val(meta), path("*.bed"), emit: bed
+    path "versions.yml"           , emit: versions
+
+    when:
+    task.ext.when == null || task.ext.when
+
+    script:
+    def args = task.ext.args ?: ''
+    def prefix = task.ext.prefix ?: "${meta.id}"
+    def arg_input = regions.extension in ["bed", "tab"] ? "-b ${regions}" : "-g ${regions}"
+    if ("${regions}" == "${prefix}.bed") error "Input and output names are the same, set prefix in module configuration to disambiguate!"
+    """
+    bedtools \\
+        makewindows \\
+        ${arg_input} \\
+        ${args} \\
+        > ${prefix}.bed
+
+    cat <<-END_VERSIONS > versions.yml
+    "${task.process}":
+        bedtools: \$(bedtools --version | sed -e "s/bedtools v//g")
+    END_VERSIONS
+    """
+
+    stub:
+    def prefix = task.ext.prefix ?: "${meta.id}"
+    if ("${regions}" == "${prefix}.bed") error "Input and output names are the same, set prefix in module configuration to disambiguate!"
+    """
+    touch ${prefix}.bed
+
+    cat <<-END_VERSIONS > versions.yml
+    "${task.process}":
+        bedtools: \$(bedtools --version | sed -e "s/bedtools v//g")
+    END_VERSIONS
+    """
+}

--- a/modules/nf-core/bedtools/makewindows/meta.yml
+++ b/modules/nf-core/bedtools/makewindows/meta.yml
@@ -1,0 +1,48 @@
+name: bedtools_makewindows
+description: Makes adjacent or sliding windows across a genome or BED file.
+keywords:
+  - bed
+  - windows
+  - fai
+  - chunking
+tools:
+  - bedtools:
+      description: A set of tools for genomic analysis tasks, specifically enabling
+        genome arithmetic (merge, count, complement) on various file types.
+      homepage: https://bedtools.readthedocs.io
+      documentation: https://bedtools.readthedocs.io/en/latest/content/tools/makewindows.html
+      doi: "10.1093/bioinformatics/btq033"
+      licence: ["MIT"]
+      identifier: biotools:bedtools
+input:
+  - - meta:
+        type: map
+        description: |
+          Groovy Map containing sample information
+          e.g. [ id:'test', single_end:false ]
+    - regions:
+        type: file
+        description: BED file OR Genome details file (<chromName><TAB><chromSize>)
+        pattern: "*.{bed,tab,fai}"
+output:
+  - bed:
+      - meta:
+          type: map
+          description: |
+            Groovy Map containing sample information
+            e.g. [ id:'test', single_end:false ]
+      - "*.bed":
+          type: file
+          description: BED file containing the windows
+          pattern: "*.bed"
+  - versions:
+      - versions.yml:
+          type: file
+          description: File containing software versions
+          pattern: "versions.yml"
+authors:
+  - "@kevbrick"
+  - "@nvnieuwk"
+maintainers:
+  - "@kevbrick"
+  - "@nvnieuwk"

--- a/modules/nf-core/bedtools/makewindows/tests/main.nf.test
+++ b/modules/nf-core/bedtools/makewindows/tests/main.nf.test
@@ -1,0 +1,58 @@
+
+nextflow_process {
+
+    name "Test Process BEDTOOLS_MAKEWINDOWS"
+    script "../main.nf"
+    process "BEDTOOLS_MAKEWINDOWS"
+    config "./nextflow.config"
+
+    tag "modules"
+    tag "modules_nfcore"
+    tag "bedtools"
+    tag "bedtools/makewindows"
+
+    test("test-bedtools-makewindows-bed") {
+
+        when {
+            process {
+                """
+                input[0] = [
+				    [ id:'test2'],
+				    file(params.modules_testdata_base_path + 'genomics/sarscov2/genome/bed/test.bed', checkIfExists: true)
+				]
+
+                """
+            }
+        }
+
+        then {
+            assertAll(
+                { assert process.success },
+                { assert snapshot(process.out).match() }
+            )
+        }
+    }
+
+    test("test-bedtools-makewindows-fai") {
+
+        when {
+            process {
+                """
+                input[0] = [
+				    [ id:'test2'],
+				    file(params.modules_testdata_base_path + 'genomics/sarscov2/genome/genome.fasta.fai', checkIfExists: true)
+				]
+
+                """
+            }
+        }
+
+        then {
+            assertAll(
+                { assert process.success },
+                { assert snapshot(process.out).match() }
+            )
+        }
+    }
+
+}

--- a/modules/nf-core/bedtools/makewindows/tests/main.nf.test.snap
+++ b/modules/nf-core/bedtools/makewindows/tests/main.nf.test.snap
@@ -1,0 +1,68 @@
+{
+    "test-bedtools-makewindows-fai": {
+        "content": [
+            {
+                "0": [
+                    [
+                        {
+                            "id": "test2"
+                        },
+                        "test2.bed:md5,622d1f62786fe4239b76c53168f21c54"
+                    ]
+                ],
+                "1": [
+                    "versions.yml:md5,f797078cc8b8bac7e6906685d4867be5"
+                ],
+                "bed": [
+                    [
+                        {
+                            "id": "test2"
+                        },
+                        "test2.bed:md5,622d1f62786fe4239b76c53168f21c54"
+                    ]
+                ],
+                "versions": [
+                    "versions.yml:md5,f797078cc8b8bac7e6906685d4867be5"
+                ]
+            }
+        ],
+        "meta": {
+            "nf-test": "0.8.4",
+            "nextflow": "24.04.4"
+        },
+        "timestamp": "2024-08-26T14:03:31.430455"
+    },
+    "test-bedtools-makewindows-bed": {
+        "content": [
+            {
+                "0": [
+                    [
+                        {
+                            "id": "test2"
+                        },
+                        "test2.bed:md5,0cf6ed2b6f470cd44a247da74ca4fe4e"
+                    ]
+                ],
+                "1": [
+                    "versions.yml:md5,f797078cc8b8bac7e6906685d4867be5"
+                ],
+                "bed": [
+                    [
+                        {
+                            "id": "test2"
+                        },
+                        "test2.bed:md5,0cf6ed2b6f470cd44a247da74ca4fe4e"
+                    ]
+                ],
+                "versions": [
+                    "versions.yml:md5,f797078cc8b8bac7e6906685d4867be5"
+                ]
+            }
+        ],
+        "meta": {
+            "nf-test": "0.8.4",
+            "nextflow": "24.04.4"
+        },
+        "timestamp": "2024-08-26T14:03:27.118372"
+    }
+}

--- a/modules/nf-core/bedtools/makewindows/tests/nextflow.config
+++ b/modules/nf-core/bedtools/makewindows/tests/nextflow.config
@@ -1,0 +1,5 @@
+process {
+    withName: BEDTOOLS_MAKEWINDOWS {
+        ext.args = '-w 50 '
+    }
+}

--- a/nextflow.config
+++ b/nextflow.config
@@ -43,7 +43,7 @@ params {
 
     // Deeptools options
     extendReads                = null
-    binSize                    = 1
+    bw_resolution              = 1
     normalizeUsing             = 'RPKM'
     effectiveGenomeSize        = null
     ignoreForNormalization     = null
@@ -52,7 +52,7 @@ params {
     corr_method                = "pearson"
     region                     = null
     numberOfSamples            = 500000
-    bam_binsize                = 50000
+    binsize                    = 50000
     fragment_size              = 100 // PARAM NOT USED (see module deeptools/plotfingerprint)
 
 

--- a/nextflow_schema.json
+++ b/nextflow_schema.json
@@ -298,9 +298,9 @@
                     "description": "Defines how much the reads should be extended",
                     "fa_icon": "fas fa-align-justify"
                 },
-                "binSize": {
+                "bw_resolution": {
                     "type": "integer",
-                    "description": "Binsize (expressed in base pairs) for genome coverage calculation (e.g. 50)",
+                    "description": "bw_resolution (expressed in base pairs) for genome coverage calculation (default 1).",
                     "default": 1,
                     "fa_icon": "fas fa-align-justify"
                 },
@@ -354,9 +354,8 @@
                     "description": "The number of bins that are sampled from the genome, for which the overlapping number of reads is computed. (Default: 500000)",
                     "fa_icon": "fas fa-align-justify"
                 },
-                "bam_binsize": {
+                "binsize": {
                     "type": "integer",
-                    "default": 50000,
                     "description": "Deeptools multiBamSummary bam bin size (Default 50000).",
                     "fa_icon": "fas fa-align-justify"
                 },

--- a/subworkflows/local/prepare_genome.nf
+++ b/subworkflows/local/prepare_genome.nf
@@ -19,9 +19,10 @@ include { GFFREAD              } from '../../modules/nf-core/gffread/main'
 include { CUSTOM_GETCHROMSIZES } from '../../modules/nf-core/custom/getchromsizes/main'
 include { BWA_INDEX            } from '../../modules/nf-core/bwa/index/main'
 include { BOWTIE2_BUILD        } from '../../modules/nf-core/bowtie2/build/main'
-
+include { BEDTOOLS_MAKEWINDOWS } from '../../modules/nf-core/bedtools/makewindows/main'
 include { GTF2BED                  } from '../../modules/local/gtf2bed'
 include { GENOME_BLACKLIST_REGIONS } from '../../modules/local/genome_blacklist_regions'
+include { BIN_BY_CHROMOSOME  } from '../../modules/local/bin_by_chromosome'
 
 workflow PREPARE_GENOME {
 
@@ -36,6 +37,7 @@ workflow PREPARE_GENOME {
 //    gene_bed           //    file: /path/to/gene.bed
     bwa_index          //    file: /path/to/bwa/index/
     bowtie2_index      //    file: /path/to/bowtie2/index/
+    bam_binsize
 
     main:
 
@@ -180,6 +182,26 @@ workflow PREPARE_GENOME {
         }
     }
     //
+    // Binning the genome bedtools/make_windows
+    //
+    ch_binned_genome = Channel.empty()
+
+    BEDTOOLS_MAKEWINDOWS (
+        ch_genome_filtered_bed.map { bed -> [ [id: bed.simpleName], bed ] }
+    )
+    ch_versions = ch_versions.mix(BEDTOOLS_MAKEWINDOWS.out.versions)
+
+    //
+    // Splitting the binned genome by chromosome
+    //
+    BIN_BY_CHROMOSOME (
+        BEDTOOLS_MAKEWINDOWS.out.bed,
+        ch_chrom_sizes
+    )
+
+    ch_binned_genome = BIN_BY_CHROMOSOME.out.chrom_beds
+
+    //
     // Uncompress CHROMAP index or generate from scratch if required
     //
     //
@@ -196,5 +218,6 @@ workflow PREPARE_GENOME {
     bwa_index     = ch_bwa_index              //    path: bwa/index/
     bowtie2_index = ch_bowtie2_index          //    path: bowtie2/index/
     blacklist     = ch_blacklist
+    binned_genome = ch_binned_genome
     versions      = ch_versions.ifEmpty(null) // channel: [ versions.yml ]
 }

--- a/workflows/sammyseq.nf
+++ b/workflows/sammyseq.nf
@@ -20,6 +20,8 @@ include { TRIMMOMATIC                 } from '../modules/nf-core/trimmomatic'
 // include { TRIMGALORE                  } from '../modules/nf-core/trimgalore/main'
 include { SAMTOOLS_FAIDX              } from '../modules/nf-core/samtools/faidx'
 include { DEEPTOOLS_BAMCOVERAGE       } from '../modules/nf-core/deeptools/bamcoverage'
+include { BEDTOOLS_MAKEWINDOWS        } from '../modules/nf-core/bedtools/makewindows/main'
+include { BIN_BY_CHROMOSOME           } from '../modules/local/bin_by_chromosome'
 
 include { FASTQ_ALIGN_BWAALN          } from '../subworkflows/nf-core/fastq_align_bwaaln/main.nf'
 include { FASTQ_ALIGN_BOWTIE2         } from '../subworkflows/nf-core/fastq_align_bowtie2/main'
@@ -105,7 +107,8 @@ workflow SAMMYSEQ {
                     params.aligner,
                     params.bwa_index,
                     params.bowtie2_index,
-                    params.blacklist)
+                    params.blacklist,
+                    params.binsize)
 
     ch_versions = ch_versions.mix(PREPARE_GENOME.out.versions)
 


### PR DESCRIPTION
I have added the make_windows module from bedtools to divide the genome in bins (default. 50000 but that can be selected with the parameter "binsize" when launching the pipeline). I have also added a local module based on awk that exctract each chromosome binned from the output of make_windows and saves each file for each chromosome.

I have changed the name of some old parameters:
From **binsize** to **bw_resolution** (bigwig scaling)
From **bam_binsize** to **binsize** (binning window)

## PR checklist

- [X] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/nf-core/sammyseq/tree/master/.github/CONTRIBUTING.md)
- [ ] If necessary, also make a PR on the nf-core/sammyseq _branch_ on the [nf-core/test-datasets](https://github.com/nf-core/test-datasets) repository.
- [X] Make sure your code lints (`nf-core pipelines lint`).
- [X] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [X] Check for unexpected warnings in debug mode (`nextflow run . -profile debug,test,docker --outdir <OUTDIR>`).
- [ ] Usage Documentation in `docs/usage.md` is updated.
- [ ] Output Documentation in `docs/output.md` is updated.
- [ ] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).
