### PR TITLE
Add bwamem aligner as option

### DIFF
--- a/conf/modules.config
+++ b/conf/modules.config
@@ -54,8 +54,16 @@ process {
         ]
     }
 
-    if (params.aligner == 'bwa') {
+    if (params.aligner == 'bwaaln') {
     withName: '.*FASTQ_ALIGN_BWAALN:.*' {
+        publishDir = [
+            enabled: false
+            ]
+        }
+    }
+
+    if (params.aligner == 'bwamem') {
+    withName: '.*FASTQ_ALIGN_DNA:.*' {
         publishDir = [
             enabled: false
             ]

--- a/modules.json
+++ b/modules.json
@@ -8,7 +8,7 @@
                     "bowtie2/align": {
                         "branch": "master",
                         "git_sha": "81880787133db07d9b4c1febd152c090eb8325dc",
-                        "installed_by": ["fastq_align_bowtie2", "modules"]
+                        "installed_by": ["fastq_align_bowtie2", "fastq_align_dna", "modules"]
                     },
                     "bowtie2/build": {
                         "branch": "master",
@@ -25,6 +25,11 @@
                         "git_sha": "2d20463181b1c38981a02e90d3084b5f9fa8d540",
                         "installed_by": ["modules"]
                     },
+                    "bwa/mem": {
+                        "branch": "master",
+                        "git_sha": "15a93581f7f81d05c04b828954004a089360ea9b",
+                        "installed_by": ["fastq_align_dna", "modules"]
+                    },
                     "bwa/sampe": {
                         "branch": "master",
                         "git_sha": "666652151335353eef2fcd58880bcef5bc2928e1",
@@ -34,6 +39,11 @@
                         "branch": "master",
                         "git_sha": "666652151335353eef2fcd58880bcef5bc2928e1",
                         "installed_by": ["fastq_align_bwaaln"]
+                    },
+                    "bwamem2/mem": {
+                        "branch": "master",
+                        "git_sha": "15a93581f7f81d05c04b828954004a089360ea9b",
+                        "installed_by": ["fastq_align_dna"]
                     },
                     "cat/fastq": {
                         "branch": "master",
@@ -84,6 +94,11 @@
                         "branch": "master",
                         "git_sha": "81880787133db07d9b4c1febd152c090eb8325dc",
                         "installed_by": ["modules"]
+                    },
+                    "dragmap/align": {
+                        "branch": "master",
+                        "git_sha": "81880787133db07d9b4c1febd152c090eb8325dc",
+                        "installed_by": ["fastq_align_dna"]
                     },
                     "fastqc": {
                         "branch": "master",
@@ -145,6 +160,11 @@
                         "git_sha": "2d20463181b1c38981a02e90d3084b5f9fa8d540",
                         "installed_by": ["modules"]
                     },
+                    "snapaligner/align": {
+                        "branch": "master",
+                        "git_sha": "81880787133db07d9b4c1febd152c090eb8325dc",
+                        "installed_by": ["fastq_align_dna"]
+                    },
                     "trimgalore": {
                         "branch": "master",
                         "git_sha": "8d3e71002c5008e3f68a691ad8cd32c346356258",
@@ -192,6 +212,11 @@
                     "fastq_align_bwaaln": {
                         "branch": "master",
                         "git_sha": "0e9cb409c32d3ec4f0d3804588e4778971c09b7e",
+                        "installed_by": ["subworkflows"]
+                    },
+                    "fastq_align_dna": {
+                        "branch": "master",
+                        "git_sha": "2d20463181b1c38981a02e90d3084b5f9fa8d540",
                         "installed_by": ["subworkflows"]
                     },
                     "utils_nextflow_pipeline": {

--- a/modules/nf-core/bwa/mem/environment.yml
+++ b/modules/nf-core/bwa/mem/environment.yml
@@ -1,0 +1,10 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/nf-core/modules/master/modules/environment-schema.json
+channels:
+  - conda-forge
+  - bioconda
+
+dependencies:
+  - bwa=0.7.18
+  - htslib=1.20.0
+  - samtools=1.20

--- a/modules/nf-core/bwa/mem/main.nf
+++ b/modules/nf-core/bwa/mem/main.nf
@@ -1,0 +1,74 @@
+process BWA_MEM {
+    tag "$meta.id"
+    label 'process_high'
+
+    conda "${moduleDir}/environment.yml"
+    container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
+        'https://depot.galaxyproject.org/singularity/mulled-v2-fe8faa35dbf6dc65a0f7f5d4ea12e31a79f73e40:1bd8542a8a0b42e0981337910954371d0230828e-0' :
+        'biocontainers/mulled-v2-fe8faa35dbf6dc65a0f7f5d4ea12e31a79f73e40:1bd8542a8a0b42e0981337910954371d0230828e-0' }"
+
+    input:
+    tuple val(meta) , path(reads)
+    tuple val(meta2), path(index)
+    tuple val(meta3), path(fasta)
+    val   sort_bam
+
+    output:
+    tuple val(meta), path("*.bam")  , emit: bam,    optional: true
+    tuple val(meta), path("*.cram") , emit: cram,   optional: true
+    tuple val(meta), path("*.csi")  , emit: csi,    optional: true
+    tuple val(meta), path("*.crai") , emit: crai,   optional: true
+    path  "versions.yml"            , emit: versions
+
+    when:
+    task.ext.when == null || task.ext.when
+
+    script:
+    def args = task.ext.args ?: ''
+    def args2 = task.ext.args2 ?: ''
+    def prefix = task.ext.prefix ?: "${meta.id}"
+    def samtools_command = sort_bam ? 'sort' : 'view'
+    def extension = args2.contains("--output-fmt sam")   ? "sam" :
+                    args2.contains("--output-fmt cram")  ? "cram":
+                    sort_bam && args2.contains("-O cram")? "cram":
+                    !sort_bam && args2.contains("-C")    ? "cram":
+                    "bam"
+    def reference = fasta && extension=="cram"  ? "--reference ${fasta}" : ""
+    if (!fasta && extension=="cram") error "Fasta reference is required for CRAM output"
+    """
+    INDEX=`find -L ./ -name "*.amb" | sed 's/\\.amb\$//'`
+
+    bwa mem \\
+        $args \\
+        -t $task.cpus \\
+        \$INDEX \\
+        $reads \\
+        | samtools $samtools_command $args2 ${reference} --threads $task.cpus -o ${prefix}.${extension} -
+
+    cat <<-END_VERSIONS > versions.yml
+    "${task.process}":
+        bwa: \$(echo \$(bwa 2>&1) | sed 's/^.*Version: //; s/Contact:.*\$//')
+        samtools: \$(echo \$(samtools --version 2>&1) | sed 's/^.*samtools //; s/Using.*\$//')
+    END_VERSIONS
+    """
+
+    stub:
+    def args2 = task.ext.args2 ?: ''
+    def prefix = task.ext.prefix ?: "${meta.id}"
+    def extension = args2.contains("--output-fmt sam")   ? "sam" :
+                    args2.contains("--output-fmt cram")  ? "cram":
+                    sort_bam && args2.contains("-O cram")? "cram":
+                    !sort_bam && args2.contains("-C")    ? "cram":
+                    "bam"
+    """
+    touch ${prefix}.${extension}
+    touch ${prefix}.csi
+    touch ${prefix}.crai
+
+    cat <<-END_VERSIONS > versions.yml
+    "${task.process}":
+        bwa: \$(echo \$(bwa 2>&1) | sed 's/^.*Version: //; s/Contact:.*\$//')
+        samtools: \$(echo \$(samtools --version 2>&1) | sed 's/^.*samtools //; s/Using.*\$//')
+    END_VERSIONS
+    """
+}

--- a/modules/nf-core/bwa/mem/meta.yml
+++ b/modules/nf-core/bwa/mem/meta.yml
@@ -1,0 +1,111 @@
+name: bwa_mem
+description: Performs fastq alignment to a fasta reference using BWA
+keywords:
+  - mem
+  - bwa
+  - alignment
+  - map
+  - fastq
+  - bam
+  - sam
+tools:
+  - bwa:
+      description: |
+        BWA is a software package for mapping DNA sequences against
+        a large reference genome, such as the human genome.
+      homepage: http://bio-bwa.sourceforge.net/
+      documentation: https://bio-bwa.sourceforge.net/bwa.shtml
+      arxiv: arXiv:1303.3997
+      licence: ["GPL-3.0-or-later"]
+      identifier: "biotools:bwa"
+input:
+  - - meta:
+        type: map
+        description: |
+          Groovy Map containing sample information
+          e.g. [ id:'test', single_end:false ]
+    - reads:
+        type: file
+        description: |
+          List of input FastQ files of size 1 and 2 for single-end and paired-end data,
+          respectively.
+        ontologies:
+          - edam: "http://edamontology.org/data_2044" # Sequence
+          - edam: "http://edamontology.org/format_1930" # FASTQ
+  - - meta2:
+        type: map
+        description: |
+          Groovy Map containing reference information.
+          e.g. [ id:'test', single_end:false ]
+    - index:
+        type: file
+        description: BWA genome index files
+        pattern: "Directory containing BWA index *.{amb,ann,bwt,pac,sa}"
+        ontologies:
+          - edam: "http://edamontology.org/data_3210" # Genome index
+  - - meta3:
+        type: map
+        description: |
+          Groovy Map containing sample information
+          e.g. [ id:'test', single_end:false ]
+    - fasta:
+        type: file
+        description: Reference genome in FASTA format
+        pattern: "*.{fasta,fa}"
+        ontologies:
+          - edam: "http://edamontology.org/data_2044" # Sequence
+          - edam: "http://edamontology.org/format_1929" # FASTA
+  - - sort_bam:
+        type: boolean
+        description: use samtools sort (true) or samtools view (false)
+        pattern: "true or false"
+output:
+  - bam:
+      - meta:
+          type: file
+          description: Output BAM file containing read alignments
+      - "*.bam":
+          type: file
+          description: Output BAM file containing read alignments
+          pattern: "*.{bam}"
+          ontologies:
+            - edam: "http://edamontology.org/format_2572" # BAM
+  - cram:
+      - meta:
+          type: file
+          description: Output CRAM file containing read alignments
+      - "*.cram":
+          type: file
+          description: Output CRAM file containing read alignments
+          pattern: "*.{cram}"
+          ontologies:
+            - edam: "http://edamontology.org/format_3462" # CRAM
+  - csi:
+      - meta:
+          type: file
+          description: Optional index file for BAM file
+      - "*.csi":
+          type: file
+          description: Optional index file for BAM file
+          pattern: "*.{csi}"
+  - crai:
+      - meta:
+          type: file
+          description: Optional index file for CRAM file
+      - "*.crai":
+          type: file
+          description: Optional index file for CRAM file
+          pattern: "*.{crai}"
+  - versions:
+      - versions.yml:
+          type: file
+          description: File containing software versions
+          pattern: "versions.yml"
+authors:
+  - "@drpatelh"
+  - "@jeremy1805"
+  - "@matthdsm"
+maintainers:
+  - "@drpatelh"
+  - "@jeremy1805"
+  - "@matthdsm"

--- a/modules/nf-core/bwa/mem/tests/main.nf.test
+++ b/modules/nf-core/bwa/mem/tests/main.nf.test
@@ -1,0 +1,260 @@
+nextflow_process {
+
+    name "Test Process BWA_MEM"
+    tag "modules_nfcore"
+    tag "modules"
+    tag "bwa"
+    tag "bwa/mem"
+    tag "bwa/index"
+    script "../main.nf"
+    process "BWA_MEM"
+
+    setup {
+        run("BWA_INDEX") {
+            script "../../index/main.nf"
+            process {
+                """
+                input[0] = [
+                    [id: 'test'],
+                    file(params.modules_testdata_base_path + 'genomics/sarscov2/genome/genome.fasta', checkIfExists: true)
+                ]
+                """
+            }
+        }
+    }
+
+    test("Single-End") {
+
+        when {
+            process {
+                """
+                input[0] = [
+                    [ id:'test', single_end:true ], // meta map
+                    [
+                        file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/fastq/test_1.fastq.gz', checkIfExists: true)
+                    ]
+                ]
+                input[1] = BWA_INDEX.out.index
+                input[2] = [[id: 'test'],file(params.modules_testdata_base_path + 'genomics/sarscov2/genome/genome.fasta', checkIfExists: true)]
+                input[3] = false
+                """
+            }
+        }
+
+        then {
+            assertAll(
+                { assert process.success },
+                { assert snapshot(
+                    process.out.cram,
+                    process.out.csi,
+                    process.out.crai,
+                    process.out.versions,
+                    bam(process.out.bam[0][1]).getHeaderMD5(),
+                    bam(process.out.bam[0][1]).getReadsMD5()
+                    ).match()
+                }
+            )
+        }
+
+    }
+
+    test("Single-End Sort") {
+
+        when {
+            process {
+                """
+                input[0] = [
+                    [ id:'test', single_end:true ], // meta map
+                    [
+                        file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/fastq/test_1.fastq.gz', checkIfExists: true)
+                    ]
+                ]
+                input[1] = BWA_INDEX.out.index
+                input[2] = [[id: 'test'],file(params.modules_testdata_base_path + 'genomics/sarscov2/genome/genome.fasta', checkIfExists: true)]
+                input[3] = true
+                """
+            }
+        }
+
+        then {
+            assertAll(
+                { assert process.success },
+                { assert snapshot(
+                    process.out.cram,
+                    process.out.csi,
+                    process.out.crai,
+                    process.out.versions,
+                    bam(process.out.bam[0][1]).getHeaderMD5(),
+                    bam(process.out.bam[0][1]).getReadsMD5()
+                    ).match()
+                }
+            )
+        }
+
+    }
+
+    test("Paired-End") {
+
+        when {
+            process {
+                """
+                input[0] = [
+                    [ id:'test', single_end:false ], // meta map
+                    [
+                        file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/fastq/test_1.fastq.gz', checkIfExists: true),
+                        file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/fastq/test_2.fastq.gz', checkIfExists: true)
+                    ]
+                ]
+                input[1] = BWA_INDEX.out.index
+                input[2] = [[id: 'test'],file(params.modules_testdata_base_path + 'genomics/sarscov2/genome/genome.fasta', checkIfExists: true)]
+                input[3] = false
+                """
+            }
+        }
+
+        then {
+            assertAll(
+                { assert process.success },
+                { assert snapshot(
+                    process.out.cram,
+                    process.out.csi,
+                    process.out.crai,
+                    process.out.versions,
+                    bam(process.out.bam[0][1]).getHeaderMD5(),
+                    bam(process.out.bam[0][1]).getReadsMD5()
+                    ).match()
+                }
+            )
+        }
+
+    }
+
+    test("Paired-End Sort") {
+
+        when {
+            process {
+                """
+                input[0] = [
+                    [ id:'test', single_end:false ], // meta map
+                    [
+                        file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/fastq/test_1.fastq.gz', checkIfExists: true),
+                        file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/fastq/test_2.fastq.gz', checkIfExists: true)
+                    ]
+                ]
+                input[1] = BWA_INDEX.out.index
+                input[2] = [[id: 'test'],file(params.modules_testdata_base_path + 'genomics/sarscov2/genome/genome.fasta', checkIfExists: true)]
+                input[3] = true
+                """
+            }
+        }
+
+        then {
+            assertAll(
+                { assert process.success },
+                { assert snapshot(
+                    process.out.cram,
+                    process.out.csi,
+                    process.out.crai,
+                    process.out.versions,
+                    bam(process.out.bam[0][1]).getHeaderMD5(),
+                    bam(process.out.bam[0][1]).getReadsMD5()
+                    ).match()
+                }
+            )
+        }
+
+    }
+
+    test("Paired-End - no fasta") {
+
+        when {
+            process {
+                """
+                input[0] = [
+                    [ id:'test', single_end:false ], // meta map
+                    [
+                        file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/fastq/test_1.fastq.gz', checkIfExists: true),
+                        file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/fastq/test_2.fastq.gz', checkIfExists: true)
+                    ]
+                ]
+                input[1] = BWA_INDEX.out.index
+                input[2] = [[:],[]]
+                input[3] = false
+                """
+            }
+        }
+
+        then {
+            assertAll(
+                { assert process.success },
+                { assert snapshot(
+                    process.out.cram,
+                    process.out.csi,
+                    process.out.crai,
+                    process.out.versions,
+                    bam(process.out.bam[0][1]).getHeaderMD5(),
+                    bam(process.out.bam[0][1]).getReadsMD5()
+                    ).match()
+                }
+            )
+        }
+
+    }
+
+    test("Single-end - stub") {
+
+        options "-stub"
+
+        when {
+            process {
+                """
+                input[0] = [
+                    [ id:'test', single_end:true ], // meta map
+                    [
+                        file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/fastq/test_1.fastq.gz', checkIfExists: true)
+                    ]
+                ]
+                input[1] = BWA_INDEX.out.index
+                input[2] = [[id: 'test'],file(params.modules_testdata_base_path + 'genomics/sarscov2/genome/genome.fasta', checkIfExists: true)]
+                input[3] = false
+                """
+            }
+        }
+
+        then {
+            assertAll(
+                { assert process.success },
+                { assert snapshot(process.out).match() }
+            )
+        }
+    }
+
+    test("Paired-end - stub") {
+
+        options "-stub"
+
+        when {
+            process {
+                """
+                input[0] = [
+                    [ id:'test', single_end:false ], // meta map
+                    [
+                        file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/fastq/test_1.fastq.gz', checkIfExists: true),
+                        file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/fastq/test_2.fastq.gz', checkIfExists: true)
+                    ]
+                ]
+                input[1] = BWA_INDEX.out.index
+                input[2] = [[id: 'test'],file(params.modules_testdata_base_path + 'genomics/sarscov2/genome/genome.fasta', checkIfExists: true)]
+                input[3] = false
+                """
+            }
+        }
+
+        then {
+            assertAll(
+                { assert process.success },
+                { assert snapshot(process.out).match() }
+            )
+        }
+    }
+}

--- a/modules/nf-core/bwa/mem/tests/main.nf.test.snap
+++ b/modules/nf-core/bwa/mem/tests/main.nf.test.snap
@@ -1,0 +1,271 @@
+{
+    "Single-End": {
+        "content": [
+            [
+                
+            ],
+            [
+                
+            ],
+            [
+                
+            ],
+            [
+                "versions.yml:md5,478b816fbd37871f5e8c617833d51d80"
+            ],
+            "b6d9cb250261a4c125413c5d867d87a7",
+            "798439cbd7fd81cbcc5078022dc5479d"
+        ],
+        "meta": {
+            "nf-test": "0.9.0",
+            "nextflow": "24.04.4"
+        },
+        "timestamp": "2024-08-02T12:22:28.051598"
+    },
+    "Single-End Sort": {
+        "content": [
+            [
+                
+            ],
+            [
+                
+            ],
+            [
+                
+            ],
+            [
+                "versions.yml:md5,478b816fbd37871f5e8c617833d51d80"
+            ],
+            "848434ae4b79cfdcb2281c60b33663ce",
+            "94fcf617f5b994584c4e8d4044e16b4f"
+        ],
+        "meta": {
+            "nf-test": "0.9.0",
+            "nextflow": "24.04.4"
+        },
+        "timestamp": "2024-08-02T12:22:39.671154"
+    },
+    "Paired-End": {
+        "content": [
+            [
+                
+            ],
+            [
+                
+            ],
+            [
+                
+            ],
+            [
+                "versions.yml:md5,478b816fbd37871f5e8c617833d51d80"
+            ],
+            "5b34d31be84478761f789e3e2e805e31",
+            "57aeef88ed701a8ebc8e2f0a381b2a6"
+        ],
+        "meta": {
+            "nf-test": "0.9.0",
+            "nextflow": "24.04.4"
+        },
+        "timestamp": "2024-08-02T12:22:51.919479"
+    },
+    "Paired-End Sort": {
+        "content": [
+            [
+                
+            ],
+            [
+                
+            ],
+            [
+                
+            ],
+            [
+                "versions.yml:md5,478b816fbd37871f5e8c617833d51d80"
+            ],
+            "69003376d9a8952622d8587b39c3eaae",
+            "af8628d9df18b2d3d4f6fd47ef2bb872"
+        ],
+        "meta": {
+            "nf-test": "0.9.0",
+            "nextflow": "24.04.4"
+        },
+        "timestamp": "2024-08-02T12:23:00.833562"
+    },
+    "Single-end - stub": {
+        "content": [
+            {
+                "0": [
+                    [
+                        {
+                            "id": "test",
+                            "single_end": true
+                        },
+                        "test.bam:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "1": [
+                    
+                ],
+                "2": [
+                    [
+                        {
+                            "id": "test",
+                            "single_end": true
+                        },
+                        "test.csi:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "3": [
+                    [
+                        {
+                            "id": "test",
+                            "single_end": true
+                        },
+                        "test.crai:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "4": [
+                    "versions.yml:md5,478b816fbd37871f5e8c617833d51d80"
+                ],
+                "bam": [
+                    [
+                        {
+                            "id": "test",
+                            "single_end": true
+                        },
+                        "test.bam:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "crai": [
+                    [
+                        {
+                            "id": "test",
+                            "single_end": true
+                        },
+                        "test.crai:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "cram": [
+                    
+                ],
+                "csi": [
+                    [
+                        {
+                            "id": "test",
+                            "single_end": true
+                        },
+                        "test.csi:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "versions": [
+                    "versions.yml:md5,478b816fbd37871f5e8c617833d51d80"
+                ]
+            }
+        ],
+        "meta": {
+            "nf-test": "0.9.0",
+            "nextflow": "24.04.4"
+        },
+        "timestamp": "2024-08-02T12:31:29.46282"
+    },
+    "Paired-End - no fasta": {
+        "content": [
+            [
+                
+            ],
+            [
+                
+            ],
+            [
+                
+            ],
+            [
+                "versions.yml:md5,478b816fbd37871f5e8c617833d51d80"
+            ],
+            "5b34d31be84478761f789e3e2e805e31",
+            "57aeef88ed701a8ebc8e2f0a381b2a6"
+        ],
+        "meta": {
+            "nf-test": "0.9.0",
+            "nextflow": "24.04.4"
+        },
+        "timestamp": "2024-08-02T12:23:09.942545"
+    },
+    "Paired-end - stub": {
+        "content": [
+            {
+                "0": [
+                    [
+                        {
+                            "id": "test",
+                            "single_end": false
+                        },
+                        "test.bam:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "1": [
+                    
+                ],
+                "2": [
+                    [
+                        {
+                            "id": "test",
+                            "single_end": false
+                        },
+                        "test.csi:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "3": [
+                    [
+                        {
+                            "id": "test",
+                            "single_end": false
+                        },
+                        "test.crai:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "4": [
+                    "versions.yml:md5,478b816fbd37871f5e8c617833d51d80"
+                ],
+                "bam": [
+                    [
+                        {
+                            "id": "test",
+                            "single_end": false
+                        },
+                        "test.bam:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "crai": [
+                    [
+                        {
+                            "id": "test",
+                            "single_end": false
+                        },
+                        "test.crai:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "cram": [
+                    
+                ],
+                "csi": [
+                    [
+                        {
+                            "id": "test",
+                            "single_end": false
+                        },
+                        "test.csi:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "versions": [
+                    "versions.yml:md5,478b816fbd37871f5e8c617833d51d80"
+                ]
+            }
+        ],
+        "meta": {
+            "nf-test": "0.9.0",
+            "nextflow": "24.04.4"
+        },
+        "timestamp": "2024-08-02T12:31:37.757037"
+    }
+}

--- a/modules/nf-core/bwa/mem/tests/tags.yml
+++ b/modules/nf-core/bwa/mem/tests/tags.yml
@@ -1,0 +1,3 @@
+bwa/mem:
+  - modules/nf-core/bwa/index/**
+  - modules/nf-core/bwa/mem/**

--- a/modules/nf-core/bwamem2/mem/environment.yml
+++ b/modules/nf-core/bwamem2/mem/environment.yml
@@ -1,0 +1,10 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/nf-core/modules/master/modules/environment-schema.json
+channels:
+  - conda-forge
+  - bioconda
+
+dependencies:
+  - bwa-mem2=2.2.1
+  - htslib=1.19.1
+  - samtools=1.19.2

--- a/modules/nf-core/bwamem2/mem/main.nf
+++ b/modules/nf-core/bwamem2/mem/main.nf
@@ -1,0 +1,83 @@
+process BWAMEM2_MEM {
+    tag "$meta.id"
+    label 'process_high'
+
+    conda "${moduleDir}/environment.yml"
+    container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
+        'https://depot.galaxyproject.org/singularity/mulled-v2-e5d375990341c5aef3c9aff74f96f66f65375ef6:2d15960ccea84e249a150b7f5d4db3a42fc2d6c3-0' :
+        'biocontainers/mulled-v2-e5d375990341c5aef3c9aff74f96f66f65375ef6:2d15960ccea84e249a150b7f5d4db3a42fc2d6c3-0' }"
+
+    input:
+    tuple val(meta), path(reads)
+    tuple val(meta2), path(index)
+    tuple val(meta3), path(fasta)
+    val   sort_bam
+
+    output:
+    tuple val(meta), path("*.sam")  , emit: sam , optional:true
+    tuple val(meta), path("*.bam")  , emit: bam , optional:true
+    tuple val(meta), path("*.cram") , emit: cram, optional:true
+    tuple val(meta), path("*.crai") , emit: crai, optional:true
+    tuple val(meta), path("*.csi")  , emit: csi , optional:true
+    path  "versions.yml"            , emit: versions
+
+    when:
+    task.ext.when == null || task.ext.when
+
+    script:
+    def args = task.ext.args ?: ''
+    def args2 = task.ext.args2 ?: ''
+    def prefix = task.ext.prefix ?: "${meta.id}"
+    def samtools_command = sort_bam ? 'sort' : 'view'
+
+    def extension_pattern = /(--output-fmt|-O)+\s+(\S+)/
+    def extension_matcher =  (args2 =~ extension_pattern)
+    def extension = extension_matcher.getCount() > 0 ? extension_matcher[0][2].toLowerCase() : "bam"
+    def reference = fasta && extension=="cram"  ? "--reference ${fasta}" : ""
+    if (!fasta && extension=="cram") error "Fasta reference is required for CRAM output"
+
+    """
+    INDEX=`find -L ./ -name "*.amb" | sed 's/\\.amb\$//'`
+
+    bwa-mem2 \\
+        mem \\
+        $args \\
+        -t $task.cpus \\
+        \$INDEX \\
+        $reads \\
+        | samtools $samtools_command $args2 -@ $task.cpus ${reference} -o ${prefix}.${extension} -
+
+    cat <<-END_VERSIONS > versions.yml
+    "${task.process}":
+        bwamem2: \$(echo \$(bwa-mem2 version 2>&1) | sed 's/.* //')
+        samtools: \$(echo \$(samtools --version 2>&1) | sed 's/^.*samtools //; s/Using.*\$//')
+    END_VERSIONS
+    """
+
+    stub:
+
+    def args2 = task.ext.args2 ?: ''
+    def prefix = task.ext.prefix ?: "${meta.id}"
+    def extension_pattern = /(--output-fmt|-O)+\s+(\S+)/
+    def extension_matcher =  (args2 =~ extension_pattern)
+    def extension = extension_matcher.getCount() > 0 ? extension_matcher[0][2].toLowerCase() : "bam"
+    if (!fasta && extension=="cram") error "Fasta reference is required for CRAM output"
+
+    def create_index = ""
+    if (extension == "cram") {
+        create_index = "touch ${prefix}.crai"
+    } else if (extension == "bam") {
+        create_index = "touch ${prefix}.csi"
+    }
+
+    """
+    touch ${prefix}.${extension}
+    ${create_index}
+
+    cat <<-END_VERSIONS > versions.yml
+    "${task.process}":
+        bwamem2: \$(echo \$(bwa-mem2 version 2>&1) | sed 's/.* //')
+        samtools: \$(echo \$(samtools --version 2>&1) | sed 's/^.*samtools //; s/Using.*\$//')
+    END_VERSIONS
+    """
+}

--- a/modules/nf-core/bwamem2/mem/meta.yml
+++ b/modules/nf-core/bwamem2/mem/meta.yml
@@ -1,0 +1,129 @@
+name: bwamem2_mem
+description: Performs fastq alignment to a fasta reference using BWA
+keywords:
+  - mem
+  - bwa
+  - alignment
+  - map
+  - fastq
+  - bam
+  - sam
+tools:
+  - bwa:
+      description: |
+        BWA-mem2 is a software package for mapping DNA sequences against
+        a large reference genome, such as the human genome.
+      homepage: https://github.com/bwa-mem2/bwa-mem2
+      documentation: http://www.htslib.org/doc/samtools.html
+      arxiv: arXiv:1303.3997
+      licence: ["MIT"]
+      identifier: "biotools:bwa-mem2"
+input:
+  - - meta:
+        type: map
+        description: |
+          Groovy Map containing sample information
+          e.g. [ id:'test', single_end:false ]
+    - reads:
+        type: file
+        description: |
+          List of input FastQ files of size 1 and 2 for single-end and paired-end data,
+          respectively.
+        ontologies:
+          - edam: "http://edamontology.org/data_2044" # Sequence
+          - edam: "http://edamontology.org/format_1930" # FASTQ
+  - - meta2:
+        type: map
+        description: |
+          Groovy Map containing reference/index information
+          e.g. [ id:'test' ]
+    - index:
+        type: file
+        description: BWA genome index files
+        pattern: "Directory containing BWA index *.{0132,amb,ann,bwt.2bit.64,pac}"
+        ontologies:
+          - edam: "http://edamontology.org/data_3210" # Genome index
+  - - meta3:
+        type: map
+        description: |
+          Groovy Map containing reference information
+          e.g. [ id:'genome' ]
+    - fasta:
+        type: file
+        description: Reference genome in FASTA format
+        pattern: "*.{fa,fasta,fna}"
+        ontologies:
+          - edam: "http://edamontology.org/data_2044" # Sequence
+          - edam: "http://edamontology.org/format_1929" # FASTA
+  - - sort_bam:
+        type: boolean
+        description: use samtools sort (true) or samtools view (false)
+        pattern: "true or false"
+output:
+  - sam:
+      - meta:
+          type: map
+          description: |
+            Groovy Map containing sample information
+            e.g. [ id:'test', single_end:false ]
+      - "*.sam":
+          type: file
+          description: Output SAM file containing read alignments
+          pattern: "*.{sam}"
+          ontologies:
+            - edam: "http://edamontology.org/format_2573" # SAM
+  - bam:
+      - meta:
+          type: map
+          description: |
+            Groovy Map containing sample information
+            e.g. [ id:'test', single_end:false ]
+      - "*.bam":
+          type: file
+          description: Output BAM file containing read alignments
+          pattern: "*.{bam}"
+          ontologies:
+            - edam: "http://edamontology.org/format_2572" # BAM
+  - cram:
+      - meta:
+          type: map
+          description: |
+            Groovy Map containing sample information
+            e.g. [ id:'test', single_end:false ]
+      - "*.cram":
+          type: file
+          description: Output CRAM file containing read alignments
+          pattern: "*.{cram}"
+          ontologies:
+            - edam: "http://edamontology.org/format_3462" # CRAM
+  - crai:
+      - meta:
+          type: map
+          description: |
+            Groovy Map containing sample information
+            e.g. [ id:'test', single_end:false ]
+      - "*.crai":
+          type: file
+          description: Index file for CRAM file
+          pattern: "*.{crai}"
+  - csi:
+      - meta:
+          type: map
+          description: |
+            Groovy Map containing sample information
+            e.g. [ id:'test', single_end:false ]
+      - "*.csi":
+          type: file
+          description: Index file for BAM file
+          pattern: "*.{csi}"
+  - versions:
+      - versions.yml:
+          type: file
+          description: File containing software versions
+          pattern: "versions.yml"
+authors:
+  - "@maxulysse"
+  - "@matthdsm"
+maintainers:
+  - "@maxulysse"
+  - "@matthdsm"

--- a/modules/nf-core/bwamem2/mem/tests/main.nf.test
+++ b/modules/nf-core/bwamem2/mem/tests/main.nf.test
@@ -1,0 +1,179 @@
+nextflow_process {
+
+    name "Test Process BWAMEM2_MEM"
+    script "../main.nf"
+    process "BWAMEM2_MEM"
+
+    tag "modules"
+    tag "modules_nfcore"
+    tag "bwamem2"
+    tag "bwamem2/mem"
+    tag "bwamem2/index"
+
+    setup {
+        run("BWAMEM2_INDEX") {
+            script "../../index/main.nf"
+            process {
+                """
+                input[0] = Channel.of([
+                    [:], // meta map
+                    [file(params.modules_testdata_base_path + 'genomics/sarscov2/genome/genome.fasta', checkIfExists: true)]
+                ])
+                """
+            }
+        }
+    }
+
+    test("sarscov2 - fastq, index, fasta, false") {
+
+        when {
+            process {
+                """
+                input[0] = Channel.of([
+                    [ id:'test', single_end:true ], // meta map
+                    [file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/fastq/test_1.fastq.gz', checkIfExists: true)]
+                ])
+                input[1] = BWAMEM2_INDEX.out.index
+                input[2] = Channel.of([[:], [file(params.modules_testdata_base_path + 'genomics/sarscov2/genome/genome.fasta', checkIfExists: true)]])
+                input[3] = false
+                """
+            }
+        }
+
+        then {
+            assertAll(
+                { assert process.success },
+                { assert snapshot(
+                    bam(process.out.bam[0][1]).getHeaderMD5(),
+                    bam(process.out.bam[0][1]).getReadsMD5(),
+                    process.out.versions
+                ).match() }
+            )
+        }
+
+    }
+
+    test("sarscov2 - fastq, index, fasta, true") {
+
+        when {
+            process {
+                """
+                input[0] = Channel.of([
+                    [ id:'test', single_end:true ], // meta map
+                    [file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/fastq/test_1.fastq.gz', checkIfExists: true)]
+                ])
+                input[1] = BWAMEM2_INDEX.out.index
+                input[2] = Channel.of([[:], [file(params.modules_testdata_base_path + 'genomics/sarscov2/genome/genome.fasta', checkIfExists: true)]])
+                input[3] = true
+                """
+            }
+        }
+
+        then {
+            assertAll(
+                { assert process.success },
+                { assert snapshot(
+                    bam(process.out.bam[0][1]).getHeaderMD5(),
+                    bam(process.out.bam[0][1]).getReadsMD5(),
+                    process.out.versions
+                ).match() }
+            )
+        }
+
+    }
+
+    test("sarscov2 - [fastq1, fastq2], index, fasta, false") {
+
+        when {
+            process {
+                """
+                input[0] = Channel.of([
+                    [ id:'test', single_end:false ], // meta map
+                    [
+                        file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/fastq/test_1.fastq.gz', checkIfExists: true),
+                        file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/fastq/test_2.fastq.gz', checkIfExists: true)
+                    ]
+                ])
+                input[1] = BWAMEM2_INDEX.out.index
+                input[2] = Channel.of([[:], [file(params.modules_testdata_base_path + 'genomics/sarscov2/genome/genome.fasta', checkIfExists: true)]])
+                input[3] = false
+                """
+            }
+        }
+
+        then {
+            assertAll(
+                { assert process.success },
+                { assert snapshot(
+                    bam(process.out.bam[0][1]).getHeaderMD5(),
+                    bam(process.out.bam[0][1]).getReadsMD5(),
+                    process.out.versions
+                ).match() }
+            )
+        }
+
+    }
+
+    test("sarscov2 - [fastq1, fastq2], index, fasta, true") {
+
+        when {
+            process {
+                """
+                input[0] = Channel.of([
+                    [ id:'test', single_end:false ], // meta map
+                    [
+                        file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/fastq/test_1.fastq.gz', checkIfExists: true),
+                        file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/fastq/test_2.fastq.gz', checkIfExists: true)
+                    ]
+                ])
+                input[1] = BWAMEM2_INDEX.out.index
+                input[2] = Channel.of([[:], [file(params.modules_testdata_base_path + 'genomics/sarscov2/genome/genome.fasta', checkIfExists: true)]])
+                input[3] = true
+                """
+            }
+        }
+
+        then {
+            assertAll(
+                { assert process.success },
+                { assert snapshot(
+                    bam(process.out.bam[0][1]).getHeaderMD5(),
+                    bam(process.out.bam[0][1]).getReadsMD5(),
+                    process.out.versions
+                ).match() }
+            )
+        }
+
+    }
+
+    test("sarscov2 - [fastq1, fastq2], index, fasta, true - stub") {
+
+        options "-stub"
+
+        when {
+            process {
+                """
+                input[0] = Channel.of([
+                    [ id:'test', single_end:false ], // meta map
+                    [
+                        file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/fastq/test_1.fastq.gz', checkIfExists: true),
+                        file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/fastq/test_2.fastq.gz', checkIfExists: true)
+                    ]
+                ])
+                input[1] = BWAMEM2_INDEX.out.index
+                input[2] = Channel.of([[:], [file(params.modules_testdata_base_path + 'genomics/sarscov2/genome/genome.fasta', checkIfExists: true)]])
+                input[3] = true
+                """
+            }
+        }
+
+        then {
+            assertAll(
+                { assert process.success },
+                { assert snapshot(process.out).match() }
+            )
+        }
+
+    }
+
+}

--- a/modules/nf-core/bwamem2/mem/tests/main.nf.test.snap
+++ b/modules/nf-core/bwamem2/mem/tests/main.nf.test.snap
@@ -1,0 +1,129 @@
+{
+    "sarscov2 - [fastq1, fastq2], index, fasta, false": {
+        "content": [
+            "eefa0f44493fd0504e734efd2f1f4a9e",
+            "57aeef88ed701a8ebc8e2f0a381b2a6",
+            [
+                "versions.yml:md5,1c1a9566f189ec077b5179bbf453c51a"
+            ]
+        ],
+        "meta": {
+            "nf-test": "0.9.0",
+            "nextflow": "24.04.4"
+        },
+        "timestamp": "2024-08-02T12:23:37.929675"
+    },
+    "sarscov2 - [fastq1, fastq2], index, fasta, true - stub": {
+        "content": [
+            {
+                "0": [
+                    
+                ],
+                "1": [
+                    [
+                        {
+                            "id": "test",
+                            "single_end": false
+                        },
+                        "test.bam:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "2": [
+                    
+                ],
+                "3": [
+                    
+                ],
+                "4": [
+                    [
+                        {
+                            "id": "test",
+                            "single_end": false
+                        },
+                        "test.csi:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "5": [
+                    "versions.yml:md5,1c1a9566f189ec077b5179bbf453c51a"
+                ],
+                "bam": [
+                    [
+                        {
+                            "id": "test",
+                            "single_end": false
+                        },
+                        "test.bam:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "crai": [
+                    
+                ],
+                "cram": [
+                    
+                ],
+                "csi": [
+                    [
+                        {
+                            "id": "test",
+                            "single_end": false
+                        },
+                        "test.csi:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "sam": [
+                    
+                ],
+                "versions": [
+                    "versions.yml:md5,1c1a9566f189ec077b5179bbf453c51a"
+                ]
+            }
+        ],
+        "meta": {
+            "nf-test": "0.9.0",
+            "nextflow": "24.04.4"
+        },
+        "timestamp": "2024-08-02T12:12:06.693567"
+    },
+    "sarscov2 - [fastq1, fastq2], index, fasta, true": {
+        "content": [
+            "7aba324f82d5b4e926a5dd7b46029cb4",
+            "af8628d9df18b2d3d4f6fd47ef2bb872",
+            [
+                "versions.yml:md5,1c1a9566f189ec077b5179bbf453c51a"
+            ]
+        ],
+        "meta": {
+            "nf-test": "0.9.0",
+            "nextflow": "24.04.4"
+        },
+        "timestamp": "2024-08-02T12:23:53.488374"
+    },
+    "sarscov2 - fastq, index, fasta, false": {
+        "content": [
+            "bc02b41697b3a8f1021b02becec24052",
+            "798439cbd7fd81cbcc5078022dc5479d",
+            [
+                "versions.yml:md5,1c1a9566f189ec077b5179bbf453c51a"
+            ]
+        ],
+        "meta": {
+            "nf-test": "0.9.0",
+            "nextflow": "24.04.4"
+        },
+        "timestamp": "2024-08-02T12:23:05.644682"
+    },
+    "sarscov2 - fastq, index, fasta, true": {
+        "content": [
+            "e41d67320815d29ba5f6e9d1ae21902a",
+            "94fcf617f5b994584c4e8d4044e16b4f",
+            [
+                "versions.yml:md5,1c1a9566f189ec077b5179bbf453c51a"
+            ]
+        ],
+        "meta": {
+            "nf-test": "0.9.0",
+            "nextflow": "24.04.4"
+        },
+        "timestamp": "2024-08-02T12:23:21.837763"
+    }
+}

--- a/modules/nf-core/bwamem2/mem/tests/tags.yml
+++ b/modules/nf-core/bwamem2/mem/tests/tags.yml
@@ -1,0 +1,2 @@
+bwamem2/mem:
+  - "modules/nf-core/bwamem2/mem/**"

--- a/modules/nf-core/dragmap/align/environment.yml
+++ b/modules/nf-core/dragmap/align/environment.yml
@@ -1,0 +1,10 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/nf-core/modules/master/modules/environment-schema.json
+channels:
+  - conda-forge
+  - bioconda
+
+dependencies:
+  - dragmap=1.3.0
+  - pigz=2.8
+  - samtools=1.18

--- a/modules/nf-core/dragmap/align/main.nf
+++ b/modules/nf-core/dragmap/align/main.nf
@@ -1,0 +1,84 @@
+process DRAGMAP_ALIGN {
+    tag "$meta.id"
+    label 'process_high'
+
+    conda "${moduleDir}/environment.yml"
+    container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
+        'https://depot.galaxyproject.org/singularity/mulled-v2-580d344d9d4a496cd403932da8765f9e0187774d:7eed251370ac7f3537c3d9472cdb2f9f5d8da1c5-0':
+        'biocontainers/mulled-v2-580d344d9d4a496cd403932da8765f9e0187774d:7eed251370ac7f3537c3d9472cdb2f9f5d8da1c5-0' }"
+
+    input:
+    tuple val(meta) , path(reads)
+    tuple val(meta2), path(hashmap)
+    tuple val(meta3), path(fasta)
+    val   sort_bam
+
+    output:
+    tuple val(meta), path("*.sam")  , emit: sam   , optional: true
+    tuple val(meta), path("*.bam")  , emit: bam   , optional: true
+    tuple val(meta), path("*.cram") , emit: cram  , optional: true
+    tuple val(meta), path("*.crai") , emit: crai  , optional: true
+    tuple val(meta), path("*.csi")  , emit: csi   , optional: true
+    tuple val(meta), path('*.log')  , emit: log
+    path "versions.yml"           , emit: versions
+
+    when:
+    task.ext.when == null || task.ext.when
+
+    script:
+    def args = task.ext.args ?: ''
+    def args2 = task.ext.args2 ?: ''
+    def prefix = task.ext.prefix ?: "${meta.id}"
+    def reads_command       = meta.single_end ? "-1 $reads" : "-1 ${reads[0]} -2 ${reads[1]}"
+    def samtools_command    = sort_bam ? 'sort' : 'view'
+    def extension_pattern   = /(--output-fmt|-O)+\s+(\S+)/
+    def extension_matcher   =  (args2 =~ extension_pattern)
+    def extension           = extension_matcher.getCount() > 0 ? extension_matcher[0][2].toLowerCase() : "bam"
+    def reference           = fasta && extension=="cram"  ? "--reference ${fasta}" : ""
+    if (!fasta && extension=="cram") error "Fasta reference is required for CRAM output"
+
+    """
+    dragen-os \\
+        -r $hashmap \\
+        $args \\
+        --num-threads $task.cpus \\
+        $reads_command \\
+        2> >(tee ${prefix}.dragmap.log >&2) \\
+        | samtools $samtools_command $args2 --threads $task.cpus ${reference} -o ${prefix}.${extension} -
+
+    cat <<-END_VERSIONS > versions.yml
+    "${task.process}":
+        dragmap: \$(echo \$(dragen-os --version 2>&1))
+        samtools: \$(echo \$(samtools --version 2>&1) | sed 's/^.*samtools //; s/Using.*\$//')
+        pigz: \$( pigz --version 2>&1 | sed 's/pigz //g' )
+    END_VERSIONS
+    """
+
+    stub:
+    def args2 = task.ext.args2 ?: ''
+    def prefix = task.ext.prefix ?: "${meta.id}"
+    def extension_pattern = /(--output-fmt|-O)+\s+(\S+)/
+    def extension_matcher =  (args2 =~ extension_pattern)
+    def extension = extension_matcher.getCount() > 0 ? extension_matcher[0][2].toLowerCase() : "bam"
+    if (!fasta && extension=="cram") error "Fasta reference is required for CRAM output"
+
+    def create_index = ""
+    if (extension == "cram") {
+        create_index = "touch ${prefix}.crai"
+    } else if (extension == "bam") {
+        create_index = "touch ${prefix}.csi"
+    }
+
+    """
+    touch ${prefix}.${extension}
+    ${create_index}
+    touch ${prefix}.log
+
+    cat <<-END_VERSIONS > versions.yml
+    "${task.process}":
+        dragmap: \$(echo \$(dragen-os --version 2>&1))
+        samtools: \$(echo \$(samtools --version 2>&1) | sed 's/^.*samtools //; s/Using.*\$//')
+        pigz: \$( pigz --version 2>&1 | sed 's/pigz //g' )
+    END_VERSIONS
+    """
+}

--- a/modules/nf-core/dragmap/align/meta.yml
+++ b/modules/nf-core/dragmap/align/meta.yml
@@ -1,0 +1,117 @@
+name: dragmap_align
+description: Performs fastq alignment to a reference using DRAGMAP
+keywords:
+  - alignment
+  - map
+  - fastq
+  - bam
+  - sam
+tools:
+  - dragmap:
+      description: Dragmap is the Dragen mapper/aligner Open Source Software.
+      homepage: https://github.com/Illumina/dragmap
+      documentation: https://github.com/Illumina/dragmap
+      tool_dev_url: https://github.com/Illumina/dragmap#basic-command-line-usage
+      licence: ["GPL v3"]
+      identifier: ""
+input:
+  - - meta:
+        type: map
+        description: |
+          Groovy Map containing sample information
+          e.g. [ id:'test', single_end:false ]
+    - reads:
+        type: file
+        description: |
+          List of input FastQ files of size 1 and 2 for single-end and paired-end data,
+          respectively.
+  - - meta2:
+        type: map
+        description: |
+          Groovy Map containing reference information
+          e.g. [ id:'test', single_end:false ]
+    - hashmap:
+        type: file
+        description: DRAGMAP hash table
+        pattern: "Directory containing DRAGMAP hash table *.{cmp,.bin,.txt}"
+  - - meta3:
+        type: map
+        description: |
+          Groovy Map containing reference information
+          e.g. [ id:'genome']
+    - fasta:
+        type: file
+        description: Genome fasta reference files
+        pattern: "*.{fa,fasta,fna}"
+  - - sort_bam:
+        type: boolean
+        description: Sort the BAM file
+output:
+  - sam:
+      - meta:
+          type: map
+          description: |
+            Groovy Map containing sample information
+            e.g. [ id:'test', single_end:false ]
+      - "*.sam":
+          type: file
+          description: Output SAM file containing read alignments
+          pattern: "*.{sam}"
+  - bam:
+      - meta:
+          type: file
+          description: Output BAM file containing read alignments
+          pattern: "*.{bam}"
+      - "*.bam":
+          type: file
+          description: Output BAM file containing read alignments
+          pattern: "*.{bam}"
+  - cram:
+      - meta:
+          type: map
+          description: |
+            Groovy Map containing sample information
+            e.g. [ id:'test', single_end:false ]
+      - "*.cram":
+          type: file
+          description: Output CRAM file containing read alignments
+          pattern: "*.{cram}"
+  - crai:
+      - meta:
+          type: map
+          description: |
+            Groovy Map containing sample information
+            e.g. [ id:'test', single_end:false ]
+      - "*.crai":
+          type: file
+          description: Index file for CRAM file
+          pattern: "*.{crai}"
+  - csi:
+      - meta:
+          type: map
+          description: |
+            Groovy Map containing sample information
+            e.g. [ id:'test', single_end:false ]
+      - "*.csi":
+          type: file
+          description: Index file for CRAM file
+          pattern: "*.{csi}"
+  - log:
+      - meta:
+          type: map
+          description: |
+            Groovy Map containing sample information
+            e.g. [ id:'test', single_end:false ]
+      - "*.log":
+          type: file
+          description: Log file
+          pattern: "*.{log}"
+  - versions:
+      - versions.yml:
+          type: file
+          description: File containing software versions
+          pattern: "versions.yml"
+authors:
+  - "@edmundmiller"
+maintainers:
+  - "@edmundmiller"

--- a/modules/nf-core/dragmap/align/tests/main.nf.test
+++ b/modules/nf-core/dragmap/align/tests/main.nf.test
@@ -1,0 +1,283 @@
+nextflow_process {
+
+    name "Test Process DRAGMAP_ALIGN"
+    script "../main.nf"
+    process "DRAGMAP_ALIGN"
+    tag "modules"
+    tag "modules_nfcore"
+    tag "dragmap"
+    tag "dragmap/align"
+    tag "dragmap/hashtable"
+
+    test("sarscov2 - fastq, hashtable, fasta, false") {
+
+        setup {
+            run("DRAGMAP_HASHTABLE") {
+                script "../../hashtable/main.nf"
+                process {
+                    """
+                    input[0] = [
+                        [id:'test'],
+                        file(params.modules_testdata_base_path + 'genomics/sarscov2/genome/genome.fasta', checkIfExists: true)
+                    ]
+                    """
+                }
+            }
+        }
+
+        when {
+            process {
+                """
+                input[0] = [
+                    [ id:'test', single_end:true ], // meta map
+                    file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/fastq/test_1.fastq.gz', checkIfExists: true)
+                ]
+                input[1] = DRAGMAP_HASHTABLE.out.hashmap
+                input[2] = [[id:'test'],file(params.modules_testdata_base_path + 'genomics/sarscov2/genome/genome.fasta', checkIfExists: true)]
+                input[3] = false //sort
+                """
+            }
+        }
+
+        then {
+            assertAll (
+                { assert process.success },
+                { assert snapshot(
+                    file(process.out.bam[0][1]).name,
+                    file(process.out.log[0][1]).readLines().findAll { it.startsWith("decompHash") },
+                    file(process.out.versions[0]).name
+                ).match() }
+            )
+        }
+
+    }
+
+    test("sarscov2 - fastq, hashtable, fasta, true") {
+
+        setup {
+            run("DRAGMAP_HASHTABLE") {
+                script "../../hashtable/main.nf"
+                process {
+                    """
+                    input[0] = [
+                        [id:'test'],
+                        file(params.modules_testdata_base_path + 'genomics/sarscov2/genome/genome.fasta', checkIfExists: true)
+                    ]
+                    """
+                }
+            }
+        }
+
+        when {
+            process {
+                """
+                input[0] = [
+                    [ id:'test', single_end:true ], // meta map
+                    file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/fastq/test_1.fastq.gz', checkIfExists: true)
+                ]
+                input[1] = DRAGMAP_HASHTABLE.out.hashmap
+                input[2] = [[id:'test'],file(params.modules_testdata_base_path + 'genomics/sarscov2/genome/genome.fasta', checkIfExists: true)]
+                input[3] = true //sort
+                """
+            }
+        }
+
+        then {
+            assertAll (
+                { assert process.success },
+                { assert snapshot(
+                    file(process.out.bam[0][1]).name,
+                    file(process.out.log[0][1]).readLines().findAll { it.startsWith("decompHash") },
+                    file(process.out.versions[0]).name
+                ).match() }
+            )
+        }
+
+    }
+
+    test("sarscov2 - [fastq1, fastq2], hashtable, fasta, false") {
+
+        setup {
+            run("DRAGMAP_HASHTABLE") {
+                script "../../hashtable/main.nf"
+                process {
+                    """
+                    input[0] = [
+                        [id:'test'],
+                        file(params.modules_testdata_base_path + 'genomics/sarscov2/genome/genome.fasta', checkIfExists: true)
+                    ]
+                    """
+                }
+            }
+        }
+
+        when {
+            process {
+                """
+                input[0] = [
+                    [ id:'test', single_end:false ], // meta map
+                    [
+                        file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/fastq/test_1.fastq.gz', checkIfExists: true),
+                        file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/fastq/test_2.fastq.gz', checkIfExists: true)
+                    ]
+                ]
+                input[1] = DRAGMAP_HASHTABLE.out.hashmap
+                input[2] = [[id:'test'],file(params.modules_testdata_base_path + 'genomics/sarscov2/genome/genome.fasta', checkIfExists: true)]
+                input[3] = false //sort
+                """
+            }
+        }
+
+        then {
+            assertAll (
+                { assert process.success },
+                { assert snapshot(
+                    file(process.out.bam[0][1]).name,
+                    file(process.out.log[0][1]).readLines().findAll { it.startsWith("decompHash") },
+                    file(process.out.versions[0]).name
+                ).match() }
+            )
+        }
+
+    }
+
+    test("sarscov2 - [fastq1, fastq2], hashtable, fasta, true") {
+
+        setup {
+            run("DRAGMAP_HASHTABLE") {
+                script "../../hashtable/main.nf"
+                process {
+                    """
+                    input[0] = [
+                        [id:'test'],
+                        file(params.modules_testdata_base_path + 'genomics/sarscov2/genome/genome.fasta', checkIfExists: true)
+                    ]
+                    """
+                }
+            }
+        }
+
+        when {
+            process {
+                """
+                input[0] = [
+                    [ id:'test', single_end:false ], // meta map
+                    [
+                        file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/fastq/test_1.fastq.gz', checkIfExists: true),
+                        file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/fastq/test_2.fastq.gz', checkIfExists: true)
+                    ]
+                ]
+                input[1] = DRAGMAP_HASHTABLE.out.hashmap
+                input[2] = [[id:'test'],file(params.modules_testdata_base_path + 'genomics/sarscov2/genome/genome.fasta', checkIfExists: true)]
+                input[3] = true //sort
+                """
+            }
+        }
+
+        then {
+            assertAll (
+                { assert process.success },
+                { assert snapshot(
+                    file(process.out.bam[0][1]).name,
+                    file(process.out.log[0][1]).readLines().findAll { it.startsWith("decompHash") },
+                    file(process.out.versions[0]).name
+                ).match() }
+            )
+        }
+
+    }
+
+    test("homo_sapiens - [fastq1, fastq2], hashtable, fasta, true") {
+
+        setup {
+            run("DRAGMAP_HASHTABLE") {
+                script "../../hashtable/main.nf"
+                process {
+                    """
+                    input[0] = [
+                        [id:'test'],
+                        file(params.modules_testdata_base_path + 'genomics/homo_sapiens/genome/genome.fasta', checkIfExists: true)
+                    ]
+                    """
+                }
+            }
+        }
+
+        when {
+            process {
+                """
+                input[0] = [
+                    [ id:'test', single_end:false ], // meta map
+                    [
+                        file(params.modules_testdata_base_path + 'genomics/homo_sapiens/illumina/fastq/test_1.fastq.gz', checkIfExists: true),
+                        file(params.modules_testdata_base_path + 'genomics/homo_sapiens/illumina/fastq/test_2.fastq.gz', checkIfExists: true)
+                    ]
+                ]
+                input[1] = DRAGMAP_HASHTABLE.out.hashmap
+                input[2] = [[id:'test'],file(params.modules_testdata_base_path + 'genomics/sarscov2/genome/genome.fasta', checkIfExists: true)]
+                input[3] = true //sort
+                """
+            }
+        }
+
+        then {
+            assertAll (
+                { assert process.success },
+                { assert snapshot(
+                    file(process.out.bam[0][1]).name,
+                    file(process.out.log[0][1]).readLines().findAll { it.startsWith("decompHash") },
+                    file(process.out.versions[0]).name
+                ).match() }
+            )
+        }
+
+    }
+
+    test("sarscov2 - [fastq1, fastq2], hashtable, fasta, true - stub") {
+
+        options "-stub"
+        setup {
+            run("DRAGMAP_HASHTABLE") {
+                script "../../hashtable/main.nf"
+                process {
+                    """
+                    input[0] = [
+                        [id:'test'],
+                        file(params.modules_testdata_base_path + 'genomics/sarscov2/genome/genome.fasta', checkIfExists: true)
+                    ]
+                    """
+                }
+            }
+        }
+
+        when {
+            process {
+                """
+                input[0] = [
+                    [ id:'test', single_end:false ], // meta map
+                    [
+                        file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/fastq/test_1.fastq.gz', checkIfExists: true),
+                        file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/fastq/test_2.fastq.gz', checkIfExists: true)
+                    ]
+                ]
+                input[1] = DRAGMAP_HASHTABLE.out.hashmap
+                input[2] = [[id:'test'],file(params.modules_testdata_base_path + 'genomics/sarscov2/genome/genome.fasta', checkIfExists: true)]
+                input[3] = true //sort
+                """
+            }
+        }
+
+        then {
+            assertAll (
+                { assert process.success },
+                { assert snapshot(
+                    file(process.out.bam[0][1]).name,
+                    file(process.out.log[0][1]).name,
+                    file(process.out.versions[0]).name
+                ).match() }
+            )
+        }
+
+    }
+
+}

--- a/modules/nf-core/dragmap/align/tests/main.nf.test.snap
+++ b/modules/nf-core/dragmap/align/tests/main.nf.test.snap
@@ -1,0 +1,109 @@
+{
+    "sarscov2 - [fastq1, fastq2], hashtable, fasta, false": {
+        "content": [
+            "test.bam",
+            [
+                "decompHashTableCtxInit...",
+                "decompHashTableHeader...",
+                "decompHashTableLiterals...",
+                "decompHashTableExtIndex...",
+                "decompHashTableAutoHits...",
+                "decompHashTableSetFlags..."
+            ],
+            "versions.yml"
+        ],
+        "meta": {
+            "nf-test": "0.8.4",
+            "nextflow": "23.10.1"
+        },
+        "timestamp": "2024-03-20T10:46:54.961203552"
+    },
+    "homo_sapiens - [fastq1, fastq2], hashtable, fasta, true": {
+        "content": [
+            "test.bam",
+            [
+                "decompHashTableCtxInit...",
+                "decompHashTableHeader...",
+                "decompHashTableLiterals...",
+                "decompHashTableExtIndex...",
+                "decompHashTableAutoHits...",
+                "decompHashTableSetFlags..."
+            ],
+            "versions.yml"
+        ],
+        "meta": {
+            "nf-test": "0.8.4",
+            "nextflow": "23.10.1"
+        },
+        "timestamp": "2024-03-20T10:47:24.495131137"
+    },
+    "sarscov2 - fastq, hashtable, fasta, true": {
+        "content": [
+            "test.bam",
+            [
+                "decompHashTableCtxInit...",
+                "decompHashTableHeader...",
+                "decompHashTableLiterals...",
+                "decompHashTableExtIndex...",
+                "decompHashTableAutoHits...",
+                "decompHashTableSetFlags..."
+            ],
+            "versions.yml"
+        ],
+        "meta": {
+            "nf-test": "0.8.4",
+            "nextflow": "23.10.1"
+        },
+        "timestamp": "2024-03-20T10:46:42.57679755"
+    },
+    "sarscov2 - [fastq1, fastq2], hashtable, fasta, true": {
+        "content": [
+            "test.bam",
+            [
+                "decompHashTableCtxInit...",
+                "decompHashTableHeader...",
+                "decompHashTableLiterals...",
+                "decompHashTableExtIndex...",
+                "decompHashTableAutoHits...",
+                "decompHashTableSetFlags..."
+            ],
+            "versions.yml"
+        ],
+        "meta": {
+            "nf-test": "0.8.4",
+            "nextflow": "23.10.1"
+        },
+        "timestamp": "2024-03-20T10:47:08.943445149"
+    },
+    "sarscov2 - [fastq1, fastq2], hashtable, fasta, true - stub": {
+        "content": [
+            "test.bam",
+            "test.log",
+            "versions.yml"
+        ],
+        "meta": {
+            "nf-test": "0.8.4",
+            "nextflow": "23.10.1"
+        },
+        "timestamp": "2024-03-20T10:47:38.346392133"
+    },
+    "sarscov2 - fastq, hashtable, fasta, false": {
+        "content": [
+            "test.bam",
+            [
+                "decompHashTableCtxInit...",
+                "decompHashTableHeader...",
+                "decompHashTableLiterals...",
+                "decompHashTableExtIndex...",
+                "decompHashTableAutoHits...",
+                "decompHashTableSetFlags..."
+            ],
+            "versions.yml"
+        ],
+        "meta": {
+            "nf-test": "0.8.4",
+            "nextflow": "23.10.1"
+        },
+        "timestamp": "2024-03-20T10:46:28.406548681"
+    }
+}

--- a/modules/nf-core/dragmap/align/tests/tags.yml
+++ b/modules/nf-core/dragmap/align/tests/tags.yml
@@ -1,0 +1,2 @@
+dragmap/align:
+  - modules/nf-core/dragmap/align/**

--- a/modules/nf-core/snapaligner/align/environment.yml
+++ b/modules/nf-core/snapaligner/align/environment.yml
@@ -1,0 +1,7 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/nf-core/modules/master/modules/environment-schema.json
+channels:
+  - conda-forge
+  - bioconda
+dependencies:
+  - bioconda::snap-aligner=2.0.3

--- a/modules/nf-core/snapaligner/align/main.nf
+++ b/modules/nf-core/snapaligner/align/main.nf
@@ -1,0 +1,43 @@
+process SNAPALIGNER_ALIGN {
+    tag "$meta.id"
+    label 'process_high'
+
+    conda "${moduleDir}/environment.yml"
+    container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
+        'https://depot.galaxyproject.org/singularity/snap-aligner:2.0.3--hd03093a_0':
+        'biocontainers/snap-aligner:2.0.3--hd03093a_0' }"
+
+    input:
+    tuple val(meta) , path(reads, stageAs: "?/*")
+    tuple val(meta2), path(index)
+
+    output:
+    tuple val(meta), path("*.bam"), emit: bam
+    tuple val(meta), path("*.bai"), optional: true, emit: bai
+    path "versions.yml"           , emit: versions
+
+    when:
+    task.ext.when == null || task.ext.when
+
+    script:
+    def args = task.ext.args ?: ''
+    def prefix = task.ext.prefix ?: "${meta.id}"
+    def subcmd = meta.single_end ? "single" : "paired"
+
+    """
+    INDEX=`dirname \$(find -L ./ -name "OverflowTable*")`
+    [ -z "\$INDEX" ] && echo "Snap index files not found" 1>&2 && exit 1
+
+    snap-aligner ${subcmd} \\
+        \$INDEX \\
+        ${reads} \\
+        -o ${prefix}.bam \\
+        -t ${task.cpus} \\
+        $args
+
+    cat <<-END_VERSIONS > versions.yml
+    "${task.process}":
+        snapaligner: \$(snap-aligner 2>&1| head -n 1 | sed 's/^.*version //;s/.\$//')
+    END_VERSIONS
+    """
+}

--- a/modules/nf-core/snapaligner/align/meta.yml
+++ b/modules/nf-core/snapaligner/align/meta.yml
@@ -1,0 +1,68 @@
+name: "snapaligner_align"
+description: Performs fastq alignment to a fasta reference using SNAP
+keywords:
+  - alignment
+  - map
+  - fastq
+  - bam
+  - sam
+tools:
+  - "snapaligner":
+      description: "Scalable Nucleotide Alignment Program -- a fast and accurate read
+        aligner for high-throughput sequencing data"
+      homepage: "http://snap.cs.berkeley.edu"
+      documentation: "https://1drv.ms/b/s!AhuEg_0yZD86hcpblUt-muHKYsG8fA?e=R8ogug"
+      tool_dev_url: "https://github.com/amplab/snap"
+      doi: "10.1101/2021.11.23.469039"
+      licence: ["Apache v2"]
+      identifier: ""
+input:
+  - - meta:
+        type: map
+        description: |
+          Groovy Map containing sample information
+          e.g. [ id:'test', single_end:false ]
+    - reads:
+        type: file
+        description: List of input fastq files of size 2 for paired fastq or 1 for bam
+          or single fastq
+        pattern: "*.{fastq.gz,fq.gz,fastq,fq,bam}"
+  - - meta2:
+        type: map
+        description: |
+          Groovy Map containing reference information
+          e.g. [ id:'test', single_end:false ]
+    - index:
+        type: file
+        description: List of SNAP genome index files
+        pattern: "{Genome,GenomeIndex,GenomeIndexHash,OverflowTable}"
+output:
+  - bam:
+      - meta:
+          type: map
+          description: |
+            Groovy Map containing sample information
+            e.g. [ id:'test', single_end:false ]
+      - "*.bam":
+          type: file
+          description: Aligned BAM file
+          pattern: "*.{bam}"
+  - bai:
+      - meta:
+          type: map
+          description: |
+            Groovy Map containing sample information
+            e.g. [ id:'test', single_end:false ]
+      - "*.bai":
+          type: file
+          description: Optional aligned BAM file index
+          pattern: "*.{bai}"
+  - versions:
+      - versions.yml:
+          type: file
+          description: File containing software versions
+          pattern: "versions.yml"
+authors:
+  - "@matthdsm"
+maintainers:
+  - "@matthdsm"

--- a/nextflow.config
+++ b/nextflow.config
@@ -22,7 +22,7 @@ params {
     save_reference             = false
 
     // Alignment
-    aligner                    = 'bwa'
+    aligner                    = 'bwamem'
     save_unaligned             = false
 
     //overall analysis options

--- a/nextflow_schema.json
+++ b/nextflow_schema.json
@@ -90,10 +90,10 @@
                 },
                 "aligner": {
                     "type": "string",
-                    "default": "bwa",
+                    "default": "bwamem",
                     "fa_icon": "fas fa-puzzle-piece",
                     "description": "Specify aligner to be used to map reads to reference genome.",
-                    "enum": ["bwa", "bowtie2"]
+                    "enum": ["bwamem", "bwaaln", "bowtie2"]
                 },
                 "bwa_index": {
                     "type": "string",

--- a/subworkflows/local/prepare_genome.nf
+++ b/subworkflows/local/prepare_genome.nf
@@ -148,7 +148,7 @@ workflow PREPARE_GENOME {
     // Prepare BWA index
     //
     ch_bwa_index = Channel.empty()
-    if (params.aligner == 'bwa') {
+    if (params.aligner == 'bwaaln' || params.aligner == 'bwamem') {
         if (params.bwa_index) {
             if (params.bwa_index.endsWith('.tar.gz')) {
                 ch_bwa_index = UNTAR_BWA_INDEX ( [ [:], params.bwa_index ] ).untar

--- a/subworkflows/nf-core/fastq_align_dna/main.nf
+++ b/subworkflows/nf-core/fastq_align_dna/main.nf
@@ -1,0 +1,69 @@
+#!/usr/bin/env nextflow
+
+//
+// FASTQ_ALIGN_DNA: Align fastq files to a reference genome
+//
+
+
+include { BOWTIE2_ALIGN                     } from "../../../modules/nf-core/bowtie2/align/main"
+include { BWA_MEM as BWAMEM1_MEM            } from '../../../modules/nf-core/bwa/mem/main'
+include { BWAMEM2_MEM as BWAMEM2_MEM        } from '../../../modules/nf-core/bwamem2/mem/main'
+include { DRAGMAP_ALIGN                     } from "../../../modules/nf-core/dragmap/align/main"
+include { SNAPALIGNER_ALIGN as SNAP_ALIGN   } from '../../../modules/nf-core/snapaligner/align/main'
+
+
+
+workflow FASTQ_ALIGN_DNA {
+    take:
+        ch_reads            // channel: [mandatory] meta, reads
+        ch_aligner_index    // channel: [mandatory] aligner index
+        ch_fasta            // channel: [mandatory] fasta file
+        aligner             // string:  [mandatory] aligner [bowtie2, bwamem, bwamem2, dragmap, snap]
+        sort                // boolean: [mandatory] true -> sort, false -> don't sort
+
+    main:
+
+        ch_bam_index    = Channel.empty()
+        ch_bam          = Channel.empty()
+        ch_reports      = Channel.empty()
+        ch_versions     = Channel.empty()
+
+        // Align fastq files to reference genome and (optionally) sort
+        if (aligner == 'bowtie2') {
+                BOWTIE2_ALIGN(ch_reads, ch_aligner_index, ch_fasta, false, sort) // if aligner is bowtie2
+                ch_bam = ch_bam.mix(BOWTIE2_ALIGN.out.bam)
+                ch_versions = ch_versions.mix(BOWTIE2_ALIGN.out.versions)
+        }
+        else if (aligner == 'bwamem'){
+                BWAMEM1_MEM  (ch_reads, ch_aligner_index, ch_fasta, sort)        // If aligner is bwa-mem
+                ch_bam = ch_bam.mix(BWAMEM1_MEM.out.bam)
+                ch_bam_index = ch_bam_index.mix(BWAMEM1_MEM.out.csi)
+                ch_versions = ch_versions.mix(BWAMEM1_MEM.out.versions)
+        }
+        else if (aligner == 'bwamem2'){
+                BWAMEM2_MEM  (ch_reads, ch_aligner_index, ch_fasta, sort)       // If aligner is bwa-mem2
+                ch_bam = ch_bam.mix(BWAMEM2_MEM.out.bam)
+                ch_versions = ch_versions.mix(BWAMEM2_MEM.out.versions)
+        }
+        else if (aligner == 'dragmap'){
+                DRAGMAP_ALIGN(ch_reads, ch_aligner_index, ch_fasta, sort)       // If aligner is dragmap
+                ch_bam = ch_bam.mix(DRAGMAP_ALIGN.out.bam)
+                ch_reports = ch_reports.mix(DRAGMAP_ALIGN.out.log)
+                ch_versions = ch_versions.mix(DRAGMAP_ALIGN.out.versions)
+        }
+        else if (aligner == 'snap'){
+            SNAP_ALIGN   (ch_reads, ch_aligner_index)                       // If aligner is snap
+            ch_bam = ch_bam.mix(SNAP_ALIGN.out.bam)
+            ch_bam_index.mix(SNAP_ALIGN.out.bai)
+            ch_versions = ch_versions.mix(SNAP_ALIGN.out.versions)
+        }
+        else {
+            error "Unknown aligner: ${aligner}"
+        }
+
+    emit:
+        bam         = ch_bam        // channel: [ [meta], bam       ]
+        bam_index   = ch_bam_index  // channel: [ [meta], csi/bai   ]
+        reports     = ch_reports    // channel: [ [meta], log       ]
+        versions    = ch_versions   // channel: [ versions.yml      ]
+}

--- a/subworkflows/nf-core/fastq_align_dna/meta.yml
+++ b/subworkflows/nf-core/fastq_align_dna/meta.yml
@@ -1,0 +1,84 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/nf-core/modules/master/subworkflows/yaml-schema.json
+name: "fastq_align_dna"
+description: Align fastq files to a reference genome
+keywords:
+  - fastq
+  - bam
+  - sort
+  - bwamem
+  - bwamem2
+  - dragmap
+  - snapaligner
+components:
+  - bowtie2/align
+  - bwa/mem
+  - bwamem2/mem
+  - dragmap/align
+  - snapaligner/align
+input:
+  - meta:
+      type: map
+      description: |
+        Groovy Map containing sample information
+        e.g. [ id:'test' ]
+  - reads:
+      type: file
+      description: |
+        List of input FastQ files of size 1 and 2 for single-end and paired-end data,
+        respectively.
+  - meta2:
+      type: map
+      description: |
+        Groovy Map containing reference information
+        e.g. [ id:'test' ]
+  - index:
+      type: file
+      description: Aligner genome index files
+      pattern: "Directory containing aligner index"
+  - meta3:
+      type: map
+      description: |
+        Groovy Map containing reference information
+        e.g. [ id:'genome' ]
+  - fasta:
+      type: file
+      description: Reference genome in fasta format
+      pattern: "*.{fa, fasta, fna}"
+  - aligner:
+      type: string
+      description: Aligner to use for alignment
+      enum:
+        - bowtie2
+        - bwa
+        - bwamem2
+        - dragmap
+        - snap
+  - sort_bam:
+      type: boolean
+      description: sort output
+output:
+  - meta:
+      type: map
+      description: |
+        Groovy Map containing sample information
+        e.g. [ id:'test' ]
+  - bam:
+      type: file
+      description: BAM file
+      pattern: "*.bam"
+  - bam_index:
+      type: file
+      description: BAM index (currently only for snapaligner)
+      pattern: "*.{bai, csi}"
+  - report:
+      type: file
+      description: Alignment report (currently only for dragmap)
+      pattern: "*.txt"
+  - versions:
+      type: file
+      description: File containing software versions
+      pattern: "versions.yml"
+authors:
+  - "@matthdsm"
+maintainers:
+  - "@matthdsm"

--- a/subworkflows/nf-core/fastq_align_dna/tests/main.nf.test
+++ b/subworkflows/nf-core/fastq_align_dna/tests/main.nf.test
@@ -1,0 +1,365 @@
+nextflow_workflow {
+
+    name "Test Subworkflow FASTQ_ALIGN_DNA"
+    script "../main.nf"
+    workflow "FASTQ_ALIGN_DNA"
+
+    tag "subworkflows"
+    tag "subworkflows_nfcore"
+    tag "subworkflows/fastq_align_dna"
+    tag "bwa"
+    tag "bwa/index"
+    tag "bwa/mem"
+    tag "bowtie2"
+    tag "bowtie2/build"
+    tag "bowtie2/align"
+    tag "bwamem2"
+    tag "bwamem2/index"
+    tag "bwamem2/mem"
+    tag "dragmap"
+    tag "dragmap/hashtable"
+    tag "dragmap/align"
+    tag "snapaligner"
+    tag "snapaligner/index"
+    tag "snapaligner/align"
+
+    test("test_fastq_align_bowtie2_SE") {
+        setup {
+            run("BOWTIE2_BUILD") {
+                script "../../../../modules/nf-core/bowtie2/build/main.nf"
+                process {
+                    """
+                    input[0] = Channel.value([ [ id:'genome' ],file(params.modules_testdata_base_path + 'genomics/sarscov2/genome/genome.fasta', checkIfExists: true)])
+                    """
+                }
+            }
+        }
+        when {
+            workflow {
+                """
+                input[0] = Channel.of([[ id:'test', single_end:true ], [file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/fastq/test_1.fastq.gz', checkIfExists: true)]])
+                input[1] = BOWTIE2_BUILD.out.index
+                input[2] = Channel.value([ [ id:'genome' ],file(params.modules_testdata_base_path + 'genomics/sarscov2/genome/genome.fasta', checkIfExists: true)])
+                input[3] = "bowtie2"
+                input[4] = true
+                """
+            }
+        }
+
+        then {
+            assertAll(
+                { assert workflow.success},
+                { assert snapshot(
+                    file(workflow.out.bam[0][1]).name,
+                    workflow.out.versions[0]
+                ).match() }
+            )
+        }
+    }
+
+    test ("test_fastq_align_bowtie2_PE"){
+        setup {
+            run("BOWTIE2_BUILD") {
+                script "../../../../modules/nf-core/bowtie2/build/main.nf"
+                process {
+                    """
+                    input[0] = Channel.value([ [ id:'genome' ],file(params.modules_testdata_base_path + 'genomics/sarscov2/genome/genome.fasta', checkIfExists: true)])
+                    """
+                }
+            }
+        }
+        when {
+            workflow {
+                """
+                input[0] = Channel.of([[ id:'test', single_end:false ], [file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/fastq/test_1.fastq.gz', checkIfExists: true), file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/fastq/test_2.fastq.gz', checkIfExists: true)]])
+                input[1] = BOWTIE2_BUILD.out.index
+                input[2] = Channel.of([ [ id:'genome' ],file(params.modules_testdata_base_path + 'genomics/sarscov2/genome/genome.fasta', checkIfExists: true)])
+                input[3] = "bowtie2"
+                input[4] = true
+                """
+            }
+        }
+
+        then {
+            assertAll(
+                { assert workflow.success},
+                { assert snapshot(
+                    file(workflow.out.bam[0][1]).name,
+                    workflow.out.versions[0]
+                ).match() }
+            )
+        }
+    }
+    test ("test_fastq_align_bwa_mem_SE"){
+        setup {
+            run("BWA_INDEX") {
+                script "../../../../modules/nf-core/bwa/index/main.nf"
+                process {
+                    """
+                    input[0] = Channel.value([ [ id:'genome' ],file(params.modules_testdata_base_path + 'genomics/sarscov2/genome/genome.fasta', checkIfExists: true)])
+                    """
+                }
+            }
+        }
+        when {
+            workflow {
+                """
+                input[0] = Channel.of([[ id:'test', single_end:true ], [file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/fastq/test_1.fastq.gz', checkIfExists: true)]])
+                input[1] = BWA_INDEX.out.index
+                input[2] = Channel.of([ [ id:'genome' ],file(params.modules_testdata_base_path + 'genomics/sarscov2/genome/genome.fasta', checkIfExists: true)])
+                input[3] = "bwamem"
+                input[4] = true
+                """
+            }
+        }
+
+        then {
+            assertAll(
+                { assert workflow.success },
+                { assert snapshot(
+                    file(workflow.out.bam[0][1]).name,
+                    workflow.out.bam_index,
+                    workflow.out.reports,
+                    workflow.out.versions,
+                    ).match()
+                }
+            )
+        }
+    }
+    test ("test_fastq_align_bwa_mem_PE"){
+        setup {
+            run("BWA_INDEX") {
+                script "../../../../modules/nf-core/bwa/index/main.nf"
+                process {
+                    """
+                    input[0] = Channel.value([ [ id:'genome' ],file(params.modules_testdata_base_path + 'genomics/sarscov2/genome/genome.fasta', checkIfExists: true)])
+                    """
+                }
+            }
+        }
+        when {
+            workflow {
+                """
+                input[0] = Channel.of([[ id:'test', single_end:false ], [file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/fastq/test_1.fastq.gz', checkIfExists: true), file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/fastq/test_2.fastq.gz', checkIfExists: true)]])
+                input[1] = BWA_INDEX.out.index
+                input[2] = Channel.of([ [ id:'genome' ],file(params.modules_testdata_base_path + 'genomics/sarscov2/genome/genome.fasta', checkIfExists: true)])
+                input[3] = "bwamem"
+                input[4] = true
+                """
+            }
+        }
+
+        then {
+            assertAll(
+                { assert workflow.success },
+                { assert snapshot(
+                    file(workflow.out.bam[0][1]).name,
+                    workflow.out.bam_index,
+                    workflow.out.reports,
+                    workflow.out.versions,
+                    ).match()
+                }
+            )
+        }
+    }
+    test ("test_fastq_align_bwamem2_SE"){
+        setup {
+            run("BWAMEM2_INDEX") {
+                script "../../../../modules/nf-core/bwamem2/index/main.nf"
+                process {
+                    """
+                    input[0] = Channel.value([ [ id:'genome' ],file(params.modules_testdata_base_path + 'genomics/sarscov2/genome/genome.fasta', checkIfExists: true)])
+                    """
+                }
+            }
+        }
+        when {
+            workflow {
+                """
+                input[0] = Channel.of([[ id:'test', single_end:true ], [file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/fastq/test_1.fastq.gz', checkIfExists: true)]])
+                input[1] = BWAMEM2_INDEX.out.index
+                input[2] = Channel.of([ [ id:'genome' ],file(params.modules_testdata_base_path + 'genomics/sarscov2/genome/genome.fasta', checkIfExists: true)])
+                input[3] = "bwamem2"
+                input[4] = true
+                """
+            }
+        }
+
+        then {
+            assertAll(
+                { assert workflow.success },
+                { assert snapshot(
+                    file(workflow.out.bam[0][1]).name,
+                    workflow.out.bam_index,
+                    workflow.out.reports,
+                    workflow.out.versions,
+                    ).match()
+                }
+            )
+        }
+    }
+    test ("test_fastq_align_bwamem2_PE"){
+        setup {
+            run("BWAMEM2_INDEX") {
+                script "../../../../modules/nf-core/bwamem2/index/main.nf"
+                process {
+                    """
+                    input[0] = Channel.value([ [ id:'genome' ],file(params.modules_testdata_base_path + 'genomics/sarscov2/genome/genome.fasta', checkIfExists: true)])
+                    """
+                }
+            }
+        }
+        when {
+            workflow {
+                """
+                input[0] = Channel.of([[ id:'test', single_end:false ], [file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/fastq/test_1.fastq.gz', checkIfExists: true), file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/fastq/test_2.fastq.gz', checkIfExists: true)]])
+                input[1] = BWAMEM2_INDEX.out.index
+                input[2] = Channel.of([ [ id:'genome' ],file(params.modules_testdata_base_path + 'genomics/sarscov2/genome/genome.fasta', checkIfExists: true)])
+                input[3] = "bwamem2"
+                input[4] = true
+                """
+            }
+        }
+
+        then {
+            assertAll(
+                { assert workflow.success },
+                { assert snapshot(
+                    file(workflow.out.bam[0][1]).name,
+                    workflow.out.bam_index,
+                    workflow.out.reports,
+                    workflow.out.versions,
+                    ).match()
+                }
+            )
+        }
+    }
+    test ("test_fastq_align_dragmap_SE"){
+        setup {
+            run("DRAGMAP_HASHTABLE") {
+                script "../../../../modules/nf-core/dragmap/hashtable/main.nf"
+                process {
+                    """
+                    input[0] = Channel.value([ [ id:'genome' ],file(params.modules_testdata_base_path + 'genomics/sarscov2/genome/genome.fasta', checkIfExists: true)])
+                    """
+                }
+            }
+        }
+        when {
+            workflow {
+                """
+                input[0] = Channel.of([[ id:'test', single_end:true ], [file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/fastq/test_1.fastq.gz', checkIfExists: true)]])
+                input[1] = DRAGMAP_HASHTABLE.out.hashmap
+                input[2] = Channel.of([ [ id:'genome' ],file(params.modules_testdata_base_path + 'genomics/sarscov2/genome/genome.fasta', checkIfExists: true)])
+                input[3] = "dragmap"
+                input[4] = true
+                """
+            }
+        }
+
+        then {
+            assertAll(
+                { assert workflow.success},
+                { assert snapshot(
+                    file(workflow.out.bam[0][1]).name,
+                    file(workflow.out.reports[0][1]).readLines().findAll { it.startsWith("decompHash") },
+                    file(workflow.out.versions[0]).name
+                ).match() }
+            )
+        }
+    }
+    test ("test_fastq_align_dragmap_PE"){
+        setup {
+            run("DRAGMAP_HASHTABLE") {
+                script "../../../../modules/nf-core/dragmap/hashtable/main.nf"
+                process {
+                    """
+                    input[0] = Channel.value([ [ id:'genome' ],file(params.modules_testdata_base_path + 'genomics/sarscov2/genome/genome.fasta', checkIfExists: true)])
+                    """
+                }
+            }
+        }
+        when {
+            workflow {
+                """
+                input[0] = Channel.of([[ id:'test', single_end:false ], [file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/fastq/test_1.fastq.gz', checkIfExists: true), file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/fastq/test_2.fastq.gz', checkIfExists: true)]])
+                input[1] = DRAGMAP_HASHTABLE.out.hashmap
+                input[2] = Channel.of([ [ id:'genome' ],file(params.modules_testdata_base_path + 'genomics/sarscov2/genome/genome.fasta', checkIfExists: true)])
+                input[3] = "dragmap"
+                input[4] = true
+                """
+            }
+        }
+
+        then {
+            assertAll(
+                { assert workflow.success},
+                { assert snapshot(
+                    file(workflow.out.bam[0][1]).name,
+                    file(workflow.out.reports[0][1]).readLines().findAll { it.startsWith("decompHash") },
+                    file(workflow.out.versions[0]).name
+                ).match() }
+            )
+        }
+    }
+    test ("test_fastq_align_snapaligner_SE"){
+        setup {
+            run("SNAPALIGNER_INDEX") {
+                script "../../../../modules/nf-core/snapaligner/index/main.nf"
+                process {
+                    """
+                    input[0] = Channel.value([ [ id:'genome' ],file(params.modules_testdata_base_path + 'genomics/sarscov2/genome/genome.fasta', checkIfExists: true), [], [], []])
+                    """
+                }
+            }
+        }
+        when {
+            workflow {
+                """
+                input[0] = Channel.of([[ id:'test', single_end:true ], [file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/fastq/test_1.fastq.gz', checkIfExists: true)]])
+                input[1] = SNAPALIGNER_INDEX.out.index
+                input[2] = Channel.of([ [ id:'genome' ],file(params.modules_testdata_base_path + 'genomics/sarscov2/genome/genome.fasta', checkIfExists: true)])
+                input[3] = "snap"
+                input[4] = true
+                """
+            }
+        }
+
+        then {
+            assertAll(
+                { assert workflow.success},
+                { assert snapshot(workflow.out).match()}
+            )
+        }
+    }
+    test ("test_fastq_align_snapaligner_PE"){
+        setup {
+            run("SNAPALIGNER_INDEX") {
+                script "../../../../modules/nf-core/snapaligner/index/main.nf"
+                process {
+                    """
+                    input[0] = Channel.value([ [ id:'genome' ],file(params.modules_testdata_base_path + 'genomics/sarscov2/genome/genome.fasta', checkIfExists: true), [], [], []])
+                    """
+                }
+            }
+        }
+        when {
+            workflow {
+                """
+                input[0] = Channel.of([[ id:'test', single_end:false ], [file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/fastq/test_1.fastq.gz', checkIfExists: true), file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/fastq/test_2.fastq.gz', checkIfExists: true)]])
+                input[1] = SNAPALIGNER_INDEX.out.index
+                input[2] = Channel.of([ [ id:'genome' ],file(params.modules_testdata_base_path + 'genomics/sarscov2/genome/genome.fasta', checkIfExists: true)])
+                input[3] = "snap"
+                input[4] = true
+                """
+            }
+        }
+
+        then {
+            assertAll(
+                { assert workflow.success},
+                { assert snapshot(workflow.out).match()}
+            )
+        }
+    }
+}

--- a/subworkflows/nf-core/fastq_align_dna/tests/main.nf.test.snap
+++ b/subworkflows/nf-core/fastq_align_dna/tests/main.nf.test.snap
@@ -1,0 +1,232 @@
+{
+    "test_fastq_align_bwamem2_PE": {
+        "content": [
+            "test.bam",
+            [
+                
+            ],
+            [
+                
+            ],
+            [
+                "versions.yml:md5,75a13fa44ba2be2f448197c66a0f33bd"
+            ]
+        ],
+        "meta": {
+            "nf-test": "0.8.4",
+            "nextflow": "23.10.1"
+        },
+        "timestamp": "2024-05-20T14:43:55.591008"
+    },
+    "test_fastq_align_dragmap_PE": {
+        "content": [
+            "test.bam",
+            [
+                "decompHashTableCtxInit...",
+                "decompHashTableHeader...",
+                "decompHashTableLiterals...",
+                "decompHashTableExtIndex...",
+                "decompHashTableAutoHits...",
+                "decompHashTableSetFlags..."
+            ],
+            "versions.yml"
+        ],
+        "meta": {
+            "nf-test": "0.8.4",
+            "nextflow": "23.10.1"
+        },
+        "timestamp": "2024-03-14T08:28:25.283436546"
+    },
+    "test_fastq_align_bwa_mem_SE": {
+        "content": [
+            "test.bam",
+            [
+                
+            ],
+            [
+                
+            ],
+            [
+                "versions.yml:md5,849e10efea643335b397cf85c0512df6"
+            ]
+        ],
+        "meta": {
+            "nf-test": "0.8.4",
+            "nextflow": "23.10.1"
+        },
+        "timestamp": "2024-05-20T08:50:33.939690087"
+    },
+    "test_fastq_align_bwamem2_SE": {
+        "content": [
+            "test.bam",
+            [
+                
+            ],
+            [
+                
+            ],
+            [
+                "versions.yml:md5,75a13fa44ba2be2f448197c66a0f33bd"
+            ]
+        ],
+        "meta": {
+            "nf-test": "0.8.4",
+            "nextflow": "23.10.1"
+        },
+        "timestamp": "2024-05-20T14:43:44.671396"
+    },
+    "test_fastq_align_bwa_mem_PE": {
+        "content": [
+            "test.bam",
+            [
+                
+            ],
+            [
+                
+            ],
+            [
+                "versions.yml:md5,849e10efea643335b397cf85c0512df6"
+            ]
+        ],
+        "meta": {
+            "nf-test": "0.8.4",
+            "nextflow": "23.10.1"
+        },
+        "timestamp": "2024-05-20T08:50:48.353981991"
+    },
+    "test_fastq_align_bowtie2_SE": {
+        "content": [
+            "test.bam",
+            "versions.yml:md5,58966b8763c923187ed92d2c99663af9"
+        ],
+        "meta": {
+            "nf-test": "0.8.4",
+            "nextflow": "23.10.1"
+        },
+        "timestamp": "2024-03-14T13:06:03.046538492"
+    },
+    "test_fastq_align_dragmap_SE": {
+        "content": [
+            "test.bam",
+            [
+                "decompHashTableCtxInit...",
+                "decompHashTableHeader...",
+                "decompHashTableLiterals...",
+                "decompHashTableExtIndex...",
+                "decompHashTableAutoHits...",
+                "decompHashTableSetFlags..."
+            ],
+            "versions.yml"
+        ],
+        "meta": {
+            "nf-test": "0.8.4",
+            "nextflow": "23.10.1"
+        },
+        "timestamp": "2024-03-14T08:28:12.991034375"
+    },
+    "test_fastq_align_bowtie2_PE": {
+        "content": [
+            "test.bam",
+            "versions.yml:md5,58966b8763c923187ed92d2c99663af9"
+        ],
+        "meta": {
+            "nf-test": "0.8.4",
+            "nextflow": "23.10.1"
+        },
+        "timestamp": "2024-03-14T13:06:21.448282757"
+    },
+    "test_fastq_align_snapaligner_PE": {
+        "content": [
+            {
+                "0": [
+                    [
+                        {
+                            "id": "test",
+                            "single_end": false
+                        },
+                        "test.bam:md5,1f4f6c38e40ddd5da7f644bb0f794aa8"
+                    ]
+                ],
+                "1": [
+                    
+                ],
+                "2": [
+                    
+                ],
+                "3": [
+                    "versions.yml:md5,ef9883fd373e293fbf6a98985d3c0308"
+                ],
+                "bam": [
+                    [
+                        {
+                            "id": "test",
+                            "single_end": false
+                        },
+                        "test.bam:md5,1f4f6c38e40ddd5da7f644bb0f794aa8"
+                    ]
+                ],
+                "bam_index": [
+                    
+                ],
+                "reports": [
+                    
+                ],
+                "versions": [
+                    "versions.yml:md5,ef9883fd373e293fbf6a98985d3c0308"
+                ]
+            }
+        ],
+        "meta": {
+            "nf-test": "0.8.4",
+            "nextflow": "23.10.1"
+        },
+        "timestamp": "2024-03-14T08:19:36.298315938"
+    },
+    "test_fastq_align_snapaligner_SE": {
+        "content": [
+            {
+                "0": [
+                    [
+                        {
+                            "id": "test",
+                            "single_end": true
+                        },
+                        "test.bam:md5,6b3188b8e48ec5c155cfe02b9a24d37a"
+                    ]
+                ],
+                "1": [
+                    
+                ],
+                "2": [
+                    
+                ],
+                "3": [
+                    "versions.yml:md5,ef9883fd373e293fbf6a98985d3c0308"
+                ],
+                "bam": [
+                    [
+                        {
+                            "id": "test",
+                            "single_end": true
+                        },
+                        "test.bam:md5,6b3188b8e48ec5c155cfe02b9a24d37a"
+                    ]
+                ],
+                "bam_index": [
+                    
+                ],
+                "reports": [
+                    
+                ],
+                "versions": [
+                    "versions.yml:md5,ef9883fd373e293fbf6a98985d3c0308"
+                ]
+            }
+        ],
+        "meta": {
+            "nf-test": "0.8.4",
+            "nextflow": "23.10.1"
+        },
+        "timestamp": "2024-03-14T08:19:23.611241423"
+    }
+}

--- a/subworkflows/nf-core/fastq_align_dna/tests/nextflow.config
+++ b/subworkflows/nf-core/fastq_align_dna/tests/nextflow.config
@@ -1,0 +1,12 @@
+process {
+    withName: BOWTIE2_BUILD {
+    }
+    withName: BWA_INDEX {
+    }
+    withName: BWAMEM2_INDEX {
+    }
+    withName: DRAGMAP_HASHTABLE {
+    }
+    withName: SNAPALIGNER_INDEX {
+    }
+}

--- a/subworkflows/nf-core/fastq_align_dna/tests/tags.yml
+++ b/subworkflows/nf-core/fastq_align_dna/tests/tags.yml
@@ -1,0 +1,2 @@
+subworkflows/fastq_align_dna:
+  - subworkflows/nf-core/fastq_align_dna/**

--- a/workflows/sammyseq.nf
+++ b/workflows/sammyseq.nf
@@ -280,7 +280,7 @@ workflow SAMMYSEQ {
         return
     }
 
-    def ch_aligned_bam
+   ch_aligned_bam = Channel.empty()
 
     if (params.aligner == 'bwaaln') {
         FASTQ_ALIGN_BWAALN(

--- a/workflows/sammyseq.nf
+++ b/workflows/sammyseq.nf
@@ -22,6 +22,7 @@ include { SAMTOOLS_FAIDX              } from '../modules/nf-core/samtools/faidx'
 include { DEEPTOOLS_BAMCOVERAGE       } from '../modules/nf-core/deeptools/bamcoverage'
 
 include { FASTQ_ALIGN_BWAALN          } from '../subworkflows/nf-core/fastq_align_bwaaln/main.nf'
+include { FASTQ_ALIGN_DNA             } from '../subworkflows/nf-core/fastq_align_dna/main'
 include { FASTQ_ALIGN_BOWTIE2         } from '../subworkflows/nf-core/fastq_align_bowtie2/main'
 include { BAM_MARKDUPLICATES_PICARD   } from '../subworkflows/nf-core/bam_markduplicates_picard'
 
@@ -281,13 +282,23 @@ workflow SAMMYSEQ {
 
     def ch_aligned_bam
 
-    if (params.aligner == 'bwa') {
+    if (params.aligner == 'bwaaln') {
         FASTQ_ALIGN_BWAALN(
             TRIMMOMATIC.out.trimmed_reads,
             PREPARE_GENOME.out.bwa_index
         )
         ch_aligned_bam = FASTQ_ALIGN_BWAALN.out.bam
         ch_versions = ch_versions.mix(FASTQ_ALIGN_BWAALN.out.versions)
+    } else if (params.aligner == 'bwamem') {
+        FASTQ_ALIGN_DNA(
+            TRIMMOMATIC.out.trimmed_reads,
+            PREPARE_GENOME.out.bwa_index,
+            ch_fasta_meta,
+            params.aligner,
+            true
+        )
+        ch_aligned_bam = FASTQ_ALIGN_DNA.out.bam
+        ch_versions = ch_versions.mix(FASTQ_ALIGN_DNA.out.versions)
     } else if (params.aligner == 'bowtie2') {
         FASTQ_ALIGN_BOWTIE2(
             TRIMMOMATIC.out.trimmed_reads,

--- a/workflows/sammyseq.nf
+++ b/workflows/sammyseq.nf
@@ -280,7 +280,7 @@ workflow SAMMYSEQ {
         return
     }
 
-   ch_aligned_bam = Channel.empty()
+    ch_aligned_bam = Channel.empty()
 
     if (params.aligner == 'bwaaln') {
         FASTQ_ALIGN_BWAALN(


### PR DESCRIPTION
We have implemented the possibility of choosing the aligner, adding bwa-mem to those already present, and then we have set up it as default aligner.
## PR checklist

- [X] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/nf-core/sammyseq/tree/master/.github/CONTRIBUTING.md)
- [ ] If necessary, also make a PR on the nf-core/sammyseq _branch_ on the [nf-core/test-datasets](https://github.com/nf-core/test-datasets) repository.
- [X] Make sure your code lints (`nf-core pipelines lint`).
- [X] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [X] Check for unexpected warnings in debug mode (`nextflow run . -profile debug,test,docker --outdir <OUTDIR>`).
- [ ] Usage Documentation in `docs/usage.md` is updated.
- [ ] Output Documentation in `docs/output.md` is updated.
- [ ] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).
