### PR TITLE
Use .fai (FASTA index) and chrom.size (chromosome size) files as input

### DIFF
--- a/nextflow.config
+++ b/nextflow.config
@@ -20,6 +20,8 @@ params {
     bwa_index                  = null
     bowtie2_index              = null
     save_reference             = false
+    chrom_sizes                = null
+    fai                        = null
 
     // Alignment
     aligner                    = 'bwa'

--- a/nextflow_schema.json
+++ b/nextflow_schema.json
@@ -373,6 +373,16 @@
                     "description": "Fragment size parameter for single-end data. When set to a positive value, it enables the --extendReads option in DeepTools, extending reads to the specified length. This parameter is only used for single-end data processing and does not affect paired-end data analysis.",
                     "fa_icon": "fas fa-align-justify",
                     "hidden": true
+                },
+                "chrom_sizes": {
+                    "type": "string",
+                    "description": "Optionally provide chromosome sizes file as input",
+                    "fa_icon": "fas fa-align-justify"
+                },
+                "fai": {
+                    "type": "string",
+                    "description": "Optionally provide FASTA index (.fai) file as input",
+                    "fa_icon": "fas fa-align-justify"
                 }
             }
         }

--- a/nextflow_schema.json
+++ b/nextflow_schema.json
@@ -382,6 +382,7 @@
                     "type": "string",
                     "description": "Optionally provide FASTA index (.fai) file as input",
                     "fa_icon": "fas fa-align-justify"
+                },
                 "gtf": {
                     "type": "string",
                     "fa_icon": "fas fa-align-justify",

--- a/subworkflows/local/prepare_genome.nf
+++ b/subworkflows/local/prepare_genome.nf
@@ -16,7 +16,8 @@ include {
 
 include { UNTARFILES           } from '../../modules/nf-core/untarfiles/main'
 include { GFFREAD              } from '../../modules/nf-core/gffread/main'
-include { CUSTOM_GETCHROMSIZES } from '../../modules/nf-core/custom/getchromsizes/main'
+include { CUSTOM_GETCHROMSIZES as CUSTOM_GETCHROMSIZES_CHROM_SIZES } from '../../modules/nf-core/custom/getchromsizes/main'
+include { CUSTOM_GETCHROMSIZES as CUSTOM_GETCHROMSIZES_FAI         } from '../../modules/nf-core/custom/getchromsizes/main'
 include { BWA_INDEX            } from '../../modules/nf-core/bwa/index/main'
 include { BOWTIE2_BUILD        } from '../../modules/nf-core/bowtie2/build/main'
 
@@ -36,6 +37,8 @@ workflow PREPARE_GENOME {
 //    gene_bed           //    file: /path/to/gene.bed
     bwa_index          //    file: /path/to/bwa/index/
     bowtie2_index      //    file: /path/to/bowtie2/index/
+    chrom_sizes        //    file: /path/to/genome.sizes
+    fai                //    file: /path/to/genome.fai
 
     main:
 
@@ -123,13 +126,40 @@ workflow PREPARE_GENOME {
     }
 */
 
-    //
     // Create chromosome sizes file
-    //
-    CUSTOM_GETCHROMSIZES ( ch_fasta.map { [ [:], it ] } )
-    ch_chrom_sizes = CUSTOM_GETCHROMSIZES.out.sizes.map { it[1] }
-    ch_fai         = CUSTOM_GETCHROMSIZES.out.fai.map{ it[1] }
-    ch_versions    = ch_versions.mix(CUSTOM_GETCHROMSIZES.out.versions)
+
+ch_chrom_sizes = Channel.empty()
+if (params.chrom_sizes) {
+    if (params.chrom_sizes.endsWith('.gz')) {
+        ch_chrom_sizes = GUNZIP_CHROM_SIZES ( [ [:], params.chrom_sizes ] ).gunzip.map{ it[1] }
+        ch_versions = ch_versions.mix(GUNZIP_CHROM_SIZES.out.versions)
+    } else {
+        ch_chrom_sizes = Channel.value(file(params.chrom_sizes))
+    }
+} else {
+    // Execute CUSTOM_GETCHROMSIZES only if params.chrom_sizes is not provided
+    CUSTOM_GETCHROMSIZES_CHROM_SIZES( ch_fasta.map { [ [:], it ] } )
+    ch_chrom_sizes = CUSTOM_GETCHROMSIZES_CHROM_SIZES.out.sizes.map { it[1] }
+    ch_versions = ch_versions.mix(CUSTOM_GETCHROMSIZES_CHROM_SIZES.out.versions)
+}
+
+// Create FASTA index
+
+ch_fai = Channel.empty()
+if (params.fai) {
+    if (params.fai.endsWith('.gz')) {
+        ch_fai = GUNZIP_FAI ( [ [:], params.fai ] ).gunzip.map{ it[1] }
+        ch_versions = ch_versions.mix(GUNZIP_FAI.out.versions)
+    } else {
+        ch_fai = Channel.value(file(params.fai))
+    }
+} else {
+    // Esegui SAMTOOLS_FAIDX solo se params.fai non è fornito
+    CUSTOM_GETCHROMSIZES_FAI ( ch_fasta.map { [ [:], it ] } )
+    ch_fai = CUSTOM_GETCHROMSIZES_FAI.out.fai.map{ it[1] }
+    ch_versions = ch_versions.mix(CUSTOM_GETCHROMSIZES_FAI.out.versions)
+}
+
 
     //
     // Prepare genome intervals for filtering by removing regions in blacklist file

--- a/workflows/sammyseq.nf
+++ b/workflows/sammyseq.nf
@@ -105,7 +105,9 @@ workflow SAMMYSEQ {
                     params.aligner,
                     params.bwa_index,
                     params.bowtie2_index,
-                    params.blacklist)
+                    params.blacklist,
+                    params.chrom_sizes,
+                    params.fai)
 
     ch_versions = ch_versions.mix(PREPARE_GENOME.out.versions)
 


### PR DESCRIPTION
I implemented the prepare_genome subworkflow by adding the possibility of giving as input two parameters: params.chrom_sizes and params.fai. Wheh launching the pipeline, these two parts will be skipped.
I also added, to the nextflow.config file, the chrom_sizes and fai parameters.

## PR checklist

- [X] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/nf-core/sammyseq/tree/master/.github/CONTRIBUTING.md)
- [ ] If necessary, also make a PR on the nf-core/sammyseq _branch_ on the [nf-core/test-datasets](https://github.com/nf-core/test-datasets) repository.
- [X] Make sure your code lints (`nf-core pipelines lint`).
- [X] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [X] Check for unexpected warnings in debug mode (`nextflow run . -profile debug,test,docker --outdir <OUTDIR>`).
- [ ] Usage Documentation in `docs/usage.md` is updated.
- [ ] Output Documentation in `docs/output.md` is updated.
- [ ] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).
