### PR TITLE
switch from CSV file to string list for comparisons

### DIFF
--- a/assets/schema_input.json
+++ b/assets/schema_input.json
@@ -35,8 +35,9 @@
             },
             "fraction": {
                 "type": "string",
+                "enum": ["S2", "S2S", "S2L", "S3", "S4"],
                 "pattern": "^\\S+$",
-                "errorMessage": "fraction must be provided and cannot contain spaces",
+                "errorMessage": "fraction cannot contain spaces and must be one of: S2, S2S, S2L, S3, S4",
                 "meta": ["fraction"]
             },
             "sample_group": {

--- a/docs/output.md
+++ b/docs/output.md
@@ -175,7 +175,7 @@ This analysis uses computeMatrix in reference-point mode to generate coverage pr
 
 ### Comparisons
 
-When `--comparisonFile` is set, the difference between sample1 and sample2 read density profile smoothed by the Gaussian kernel is calculated and saved in bigwig format, as described in Kharchenko PK, Tolstorukov MY, Park PJ "Design and analysis of ChIP-seq experiments for DNA-binding proteins" Nat. Biotech. doi:10.1038/nbt.1508
+When `--comparison` is set, the difference between sample1 and sample2 read density profile smoothed by the Gaussian kernel is calculated and saved in bigwig format, as described in Kharchenko PK, Tolstorukov MY, Park PJ "Design and analysis of ChIP-seq experiments for DNA-binding proteins" Nat. Biotech. doi:10.1038/nbt.1508
 
 <details markdown="1">
 <summary>Output files</summary>

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -94,19 +94,40 @@ CTRL004_S4,/home/sammy/test_data/CTRL004_S4_chr22only.fq.gz,,CTRL004,S4
 | `experimentalID` | Experimental sample identifier. This represents the biological specimen of interest and will be the same for all fractions exctracted.                                                 |
 | `fraction`       | Fraction derived from SAMMY protocol, e.g. depending on the protocol it can be S2, S2L, S2S, S3, S4.                                                                                   |
 
-### Pairwise comparisons
+### Fraction comparisons
 
-It is possible to generate pairwise comparisons between two samples by providing a list with the parameter `--comparisonFile` to indicate the full path to a comma-separated file with 2 columns:
+It is possible to generate one or more pairwise comparisons between fractions from the same experimental replicate by providing the `--comparison` parameter. You can specify a single comparison or multiple comparisons separated by commas:
 
-`comparisons.csv`:
-
-```csv
-sample1,sample2
-CTRL004_S2,CTRL004_S3
-CTRL004_S2,CTRL004_S4
+**Single comparison:**
+```bash
+--comparison S2SvsS3
 ```
 
-It can contain any combination of sample identifiers, they have to correspond to identifiers present in the `sample` column in the input file. When `--comparisonFile` is set, the difference between sample1 and sample2 read density profile, smoothed by the Gaussian kernel, is calculated and saved in bigwig format, as described in Kharchenko PK, Tolstorukov MY, Park PJ "Design and analysis of ChIP-seq experiments for DNA-binding proteins" Nat Biotech [doi](https://doi.org/10.1038/nbt.1508).
+**Multiple comparisons:**
+
+```
+--comparison S2SvsS3,S2SvsS4,S4vsS3
+```
+
+For 4f-SAMMYseq protocols (S2S, S2L, S3, S4), valid comparisons are:
+
+    S2SvsS3  - Compare S2S fraction vs S3 fraction
+    S2LvsS3  - Compare S2L fraction vs S3 fraction
+    S2SvsS4  - Compare S2S fraction vs S4 fraction
+    S2LvsS4  - Compare S2L fraction vs S4 fraction
+    S3vsS4   - Compare S3 fraction vs S4 fraction
+    S2SvsS2L - Compare S2S fraction vs S2L fraction
+
+> [!NOTE]
+> For 3f-SAMMYseq protocols (S2, S3, S4), valid comparisons are:
+
+    S2vsS3   - Compare S2 fraction vs S3 fraction
+    S2vsS4   - Compare S2 fraction vs S4 fraction
+    S4vsS3   - Compare S4 fraction vs S3 fraction
+
+The pipeline will automatically create comparisons only between fractions from the same experimentalID (biological replicate), ensuring that comparisons are made within the same experimental condition rather than across different replicates.
+
+Any valid comparisons from the protocol type can be combined, and the fractions must correspond to those present in the fraction column of the samplesheet. When `--comparison` is set, the difference between sample1 and sample2 read density profile, smoothed by the Gaussian kernel, is calculated and saved in bigwig format, as described in Kharchenko PK, Tolstorukov MY, Park PJ "Design and analysis of ChIP-seq experiments for DNA-binding proteins" Nat Biotech [doi](https://doi.org/10.1038/nbt.1508).
 
 ### Combine fractions
 

--- a/nextflow.config
+++ b/nextflow.config
@@ -11,7 +11,7 @@ params {
 
     // Input options
     input                      = null
-    comparisonFile             = null
+    comparison                 = null  
 
     // References
     genome                     = null

--- a/nextflow_schema.json
+++ b/nextflow_schema.json
@@ -23,13 +23,11 @@
                     "help_text": "You will need to create a design file with information about the samples in your experiment before running the pipeline. Use this parameter to specify its location. It has to be a comma-separated file with 5 columns, and a header row. See [usage docs](https://nf-co.re/sammyseq/usage#samplesheet-input).",
                     "fa_icon": "fas fa-file-csv"
                 },
-                "comparisonFile": {
+                "comparison": {
                     "type": "string",
-                    "fa_icon": "fas fa-file-csv",
-                    "description": "Path to comma-separated file containing the sample names for the desired paired comparisons.",
-                    "help_text": "You will need to create a comparisons file with information about the desired comparisons in your experiment before running the pipeline. It has to be a comma-separated file with 2 columns: one for the first sample to compare and the second one to sample against which to do it. The sample names must match the sample names present in the first column of the samplesheet (`--input` parameter).",
-                    "format": "file-path",
-                    "mimetype": "text/csv"
+                    "fa_icon": "fas fa-percentage",
+                    "description": "Fraction comparisons per experimentalID (e.g., \"S2SvsS3\" or \"S2SvsS3,S2LvsS3\")",
+                    "pattern": "^(S2SvsS3|S2LvsS3|S2SvsS4|S2LvsS4|S2SvsS2L|S2vsS3|S2vsS4|S4vsS3)(,(S2SvsS3|S2LvsS3|S2SvsS4|S2LvsS4|S2SvsS2L|S2vsS3|S2vsS4|S4vsS3))*$"
                 },
                 "outdir": {
                     "type": "string",

--- a/workflows/sammyseq.nf
+++ b/workflows/sammyseq.nf
@@ -93,7 +93,8 @@ workflow SAMMYSEQ {
                     params.binsize,
                     params.gtf,
                     params.gene_bed,
-                    params.tss_bed,)
+                    params.tss_bed)
+
     ch_versions = ch_versions.mix(PREPARE_GENOME.out.versions)
 
     if (params.stopAt == 'PREPARE_GENOME') {
@@ -318,7 +319,7 @@ if (params.stopAt == 'ALIGNMENT') {
     //
     // GENOME BINNING: Run only if comparisonFile is provided
     //
-    if (params.comparisonFile) {
+    if (params.comparison) {
         GENOME_BINNING(
             PREPARE_GENOME.out.filtered_bed,
             params.keep_regions_bed
@@ -326,34 +327,41 @@ if (params.stopAt == 'ALIGNMENT') {
         ch_versions = ch_versions.mix(GENOME_BINNING.out.versions)
     }
 
-    if (params.comparisonFile) {
-        // Add the suffix "_T1" to each sample ID in the comparison file
+    //
+    // rtwosamplesmle.R module
+    //
 
-        ch_bam_input=FILTER_BAM_SAMTOOLS.out.bam
+    if (params.comparison) {
+        def comparison_list = params.comparison.split(',').collect { it.trim() }
 
-        ch_bam_input.view()
+        ch_bam_input = FILTER_BAM_SAMTOOLS.out.bam
+        //ch_bam_input.view()
 
-        // 1. Create a Comparisons Channels (one for sample 1 in comparison and another for sample 2 in comparison)
+        // 1. Create comparison channels (one for sample1 and one for sample2 in each comparison)
+        ch_samplesheet
+            .map { meta, fastqs -> meta }                   
+            .collect()                                       
+            .flatMap { meta_list ->                         
+                comparison_list.collectMany { comp ->        
+                    def (frac1, frac2) = comp.split('vs')   // Split comparison string into two fractions
+                    def samples_by_expID = meta_list.groupBy { it.experimentalID } // Group samples by experimental ID
+                    // For each experimental ID, find samples for the two fractions and create a list of comparisons
+                    samples_by_expID.collectMany { exp_id, samples -> 
+                        def s1 = samples.find { it.fraction == frac1 }?.id
+                        def s2 = samples.find { it.fraction == frac2 }?.id
 
-        Channel
-            .fromPath(params.comparisonFile)
-            .splitCsv(header : true)
-            .map{ row ->
-                //[ row.sample1 + "_T1", row.sample2 + "_T1",row.sample1 + "_T1_VS_" + row.sample2 + "_T1"]
-                //[ row.sample1 + "_T1", row.sample1 + "_T1_VS_" + row.sample2 + "_T1"]
-                [ row.sample1 , row.sample1 + "_VS_" + row.sample2 ]
+                        (s1 && s2) ? [[sample1: s1, sample2: s2]] : [] // Return comparison map if both samples exist, empty list otherwise
+                    }
                 }
-                .set { comparisons_ch_s1 }
+            }
+            .multiMap { row ->      // Split into separate channels for sample1 and sample2
+                comparisons_ch_s1: [row.sample1, "${row.sample1}_VS_${row.sample2}"]  
+                comparisons_ch_s2: [row.sample2, "${row.sample1}_VS_${row.sample2}"]  
+            }
+            .set { comparisons_ch }                          
 
-
-        Channel.fromPath(params.comparisonFile)
-                .splitCsv(header : true)
-                .map{ row ->
-                    // [ row.sample2 + "_T1", row.sample1 + "_T1",row.sample1 + "_T1_VS_" + row.sample2 + "_T1"]
-                    //[ row.sample2 + "_T1", row.sample1 + "_T1_VS_" + row.sample2 + "_T1"]
-                    [ row.sample2 , row.sample1 + "_VS_" + row.sample2 ]
-                }
-                .set { comparisons_ch_s2 }
+        comparisons_ch_s1 = comparisons_ch.comparisons_ch_s1  
+        comparisons_ch_s2 = comparisons_ch.comparisons_ch_s2  
 
         //2. convert bam file to input
         // [[id:ggg, paired:true],path.bam]
@@ -361,7 +369,6 @@ if (params.stopAt == 'ALIGNMENT') {
                 .map {meta, bam ->
                     id=meta.subMap('id')
                     [id.id, bam]
-
                     }
                 .set { ch_bam_reformat }
 
@@ -374,7 +381,6 @@ if (params.stopAt == 'ALIGNMENT') {
                 }
                 .set { bam1_comparison }
 
-                        //.view{"join= ${it}"}
         comparisons_ch_s2
                 .combine(ch_bam_reformat, by:0)
                 .map{ sample2, comparison, bam ->
@@ -386,7 +392,7 @@ if (params.stopAt == 'ALIGNMENT') {
         bam1_comparison
                 .join(bam2_comparison, remainder: false, by: 0 )
                 .set{comparisons_merge_ch}
-
+        
         //comparisons_merge_ch
         //        .view{ "comparisons_merge_ch: ${it}" }
 


### PR DESCRIPTION
This PR replaces the CSV-based comparison input with a more user-friendly string parameter approach.

- replaced --comparisonFile with --comparison parameter. now comparisons can be specified directly as comma separated strings ( S2SvsS3,S2LvsS3 )
- Added pattern based validation for comparison strings with clear error messages
- modified comparison logic: Comparisons are now grouped by experimentalIDm to ensure within-replicate comparisons only
- updateed docs/usage.md to reflect the new parameter usage and provide clear examples for both 3f and 4f-SAMMYseq protocols


## PR checklist

- [X] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/nf-core/sammyseq/tree/master/.github/CONTRIBUTING.md)
- [ ] If necessary, also make a PR on the nf-core/sammyseq _branch_ on the [nf-core/test-datasets](https://github.com/nf-core/test-datasets) repository.
- [X] Make sure your code lints (`nf-core pipelines lint`).
- [X] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [X] Check for unexpected warnings in debug mode (`nextflow run . -profile debug,test,docker --outdir <OUTDIR>`).
- [X] Usage Documentation in `docs/usage.md` is updated.
- [X] Output Documentation in `docs/output.md` is updated.
- [ ] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).
